### PR TITLE
fix(eth): TxidPage missing explorer link for swaps/sends

### DIFF
--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -1321,12 +1321,22 @@ const sendTransaction = async (params: any, KEEPKEY_WALLET: any, ADDRESS: string
     response.txid = txHash;
     await requestStorage.updateEventById(id, response);
 
+    // Defensive explorer-link resolution: if the stored provider was built
+    // through a code path that didn't carry explorerTxLink (e.g., older
+    // saved state), look it up from the static EIP155_CHAINS table by
+    // networkId. Otherwise the TxidPage gets no link and the user sees a
+    // bare hex hash with no way to navigate to etherscan.
+    let explorerTxLink = currentProvider.explorerTxLink;
+    if (!explorerTxLink && currentProvider.networkId) {
+      explorerTxLink = EIP155_CHAINS[currentProvider.networkId]?.explorerTxLink;
+    }
+
     //push event
     chrome.runtime.sendMessage({
       action: 'transaction_complete',
       eventId: id,
       txHash: txHash,
-      explorerTxLink: currentProvider.explorerTxLink,
+      explorerTxLink,
       networkId: currentProvider.networkId,
     });
 

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1001,6 +1001,12 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
                       name: chainInfo.name,
                       providerUrl: chainInfo.rpc,
                       fallbacks: [],
+                      // Carry the static chain's explorer URL forward so
+                      // transaction_complete events fired from sendTransaction
+                      // have somewhere to deep-link the txid. Without this
+                      // the TxidPage shows just the hex hash with no link.
+                      explorerTxLink: chainInfo.explorerTxLink,
+                      networkId: asset.networkId,
                     };
                   } else {
                     console.error(tag, 'Network not found in custom or static chains:', asset.networkId);


### PR DESCRIPTION
## Symptom

After a successful Uniswap swap (and ETH-side sends in general), the **Transaction Complete** card in the side panel rendered the txid as plain hex with no link — no inline anchor, no "View on Explorer" button. Reproduced today on a successful LINK swap at \`0x6954a533…94b27968a9\`.

## Root cause

\`sendTransaction\` reads \`currentProvider.explorerTxLink\` when broadcasting \`transaction_complete\` to the side panel. Two \`SET_ASSET_CONTEXT\` code paths built that provider object without the field:

1. **EIP155_CHAINS fallback** at \`chrome-extension/src/background/index.ts:996\` — copies \`chainId\`/\`caip\`/\`name\`/\`providerUrl\` but drops \`explorerTxLink\` (and \`networkId\`).

When a user picked Ethereum from the side-panel header (which goes through this fallback), the stored provider had no explorer URL → \`transaction_complete\` fired with \`explorerTxLink: undefined\` → \`TxidPage\` got no link to render → bare hex.

\`switchToProvider\` (the \`wallet_switchEthereumChain\` path) already handled it correctly by carrying through whatever the dApp passed.

## Fix

- **Carry forward** in the EIP155_CHAINS fallback so future sends have the link.
- **Safety net** in \`sendTransaction\`: if \`currentProvider.explorerTxLink\` is still missing at broadcast time, look it up from \`EIP155_CHAINS\` by \`networkId\`. Catches any remaining stored state built by older code paths.

\`TxidPage\` itself was already correctly handling \`explorerUrl\` — it renders a clickable link + a "View on Explorer" button when present. The bug was upstream.

## Test plan

- [ ] Reload the extension, switch to Ethereum from the side-panel header.
- [ ] Send a small amount of ETH (or do another Uniswap swap).
- [ ] Confirm the **Transaction Complete** card shows a clickable txid + "View on Explorer" button that opens https://etherscan.io/tx/HASH.
- [ ] Repeat for at least one L2 (Arbitrum / Base / Optimism) to confirm the per-chain explorer URL resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)