### PR TITLE
test: vitest foundation + unit tests for money/safety-path logic

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -11,6 +11,7 @@
     "build": "pnpm build:injected && vite build",
     "dev": "cross-env __DEV__=true NODE_ENV=development pnpm build:injected && vite build --mode development",
     "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint ./ --ext .ts,.js,.tsx,.jsx",
     "lint:fix": "pnpm lint --fix",
     "prettier": "prettier . --write --ignore-path ../.prettierignore",
@@ -42,6 +43,7 @@
     "cross-env": "^7.0.3",
     "deepmerge": "^4.3.1",
     "magic-string": "^0.30.11",
-    "ts-loader": "^9.5.1"
+    "ts-loader": "^9.5.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/chrome-extension/src/background/chains/feeFloors.test.ts
+++ b/chrome-extension/src/background/chains/feeFloors.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { getFeeFloor, getPriorityFeeFloor, toBigInt, buildFeeWarning } from './feeFloors';
+
+const GWEI = 1_000_000_000n;
+const gwei = (n: number | bigint) => BigInt(n) * GWEI;
+const hex = (v: bigint) => '0x' + v.toString(16);
+
+describe('toBigInt', () => {
+  it('passes through bigint', () => {
+    expect(toBigInt(5n)).toBe(5n);
+  });
+
+  it('converts a number', () => {
+    expect(toBigInt(42)).toBe(42n);
+  });
+
+  it('parses a hex string', () => {
+    expect(toBigInt('0x10')).toBe(16n);
+  });
+
+  it('parses a decimal string', () => {
+    expect(toBigInt('1000000000')).toBe(GWEI);
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(toBigInt(null)).toBeNull();
+    expect(toBigInt(undefined)).toBeNull();
+  });
+});
+
+describe('getFeeFloor', () => {
+  it('uses the static per-chain floor when base fee is unknown', () => {
+    // Ethereum static floor is 1 gwei.
+    expect(getFeeFloor('0x1', null)).toBe(gwei(1));
+    // Polygon static floor is 30 gwei.
+    expect(getFeeFloor('0x89', undefined)).toBe(gwei(30));
+  });
+
+  it('defaults unknown chains to a 1 gwei floor', () => {
+    expect(getFeeFloor('0xdead', null)).toBe(gwei(1));
+  });
+
+  it('returns the dynamic floor (baseFee * 1.1) when it exceeds the static floor', () => {
+    // Ethereum: static 1 gwei, baseFee 50 gwei -> dynamic 55 gwei wins.
+    expect(getFeeFloor('0x1', gwei(50))).toBe((gwei(50) * 11n) / 10n);
+  });
+
+  it('returns the static floor when it exceeds the dynamic floor', () => {
+    // Polygon: static 30 gwei, baseFee 1 gwei -> dynamic 1.1 gwei loses.
+    expect(getFeeFloor('0x89', gwei(1))).toBe(gwei(30));
+  });
+
+  it('normalizes a decimal-string chainId to hex before lookup', () => {
+    // "137" === 0x89 (Polygon), static floor 30 gwei.
+    expect(getFeeFloor('137', null)).toBe(gwei(30));
+  });
+
+  it('normalizes a numeric chainId', () => {
+    // 1 -> 0x1 (Ethereum).
+    expect(getFeeFloor(1, null)).toBe(gwei(1));
+  });
+
+  it('is case-insensitive on hex chainIds', () => {
+    expect(getFeeFloor('0xA86A', null)).toBe(gwei(25)); // Avalanche
+  });
+});
+
+describe('getPriorityFeeFloor', () => {
+  it('returns the configured tip floor for a known chain', () => {
+    expect(getPriorityFeeFloor('0x1')).toBe(gwei(1)); // Ethereum
+    expect(getPriorityFeeFloor('0x89')).toBe(gwei(25)); // Polygon
+  });
+
+  it('returns 0 for sequencer-driven L2s', () => {
+    expect(getPriorityFeeFloor('0xa')).toBe(0n); // Optimism
+    expect(getPriorityFeeFloor('0xa4b1')).toBe(0n); // Arbitrum
+    expect(getPriorityFeeFloor('0x2105')).toBe(0n); // Base
+  });
+
+  it('defaults unknown chains to 1 gwei', () => {
+    expect(getPriorityFeeFloor('0xdead')).toBe(gwei(1));
+  });
+});
+
+describe('buildFeeWarning', () => {
+  const ethOk = {
+    chainId: '0x1',
+    baseFeeWei: gwei(20),
+    oracleMaxFeePerGas: gwei(45),
+    oracleMaxPriorityFeePerGas: gwei(2),
+  };
+
+  it('returns null when the dApp supplies no maxFeePerGas', () => {
+    const w = buildFeeWarning({
+      ...ethOk,
+      dappMaxFeePerGas: undefined,
+      dappMaxPriorityFeePerGas: hex(gwei(2)),
+    });
+    expect(w).toBeNull();
+  });
+
+  it('returns null when fees comfortably clear both floors', () => {
+    const w = buildFeeWarning({
+      ...ethOk,
+      // maxFee 60 gwei (> baseFee*1.1=22), tip 3 gwei (> 1 gwei floor)
+      dappMaxFeePerGas: hex(gwei(60)),
+      dappMaxPriorityFeePerGas: hex(gwei(3)),
+    });
+    expect(w).toBeNull();
+  });
+
+  it("flags 'maxFee' when the dApp maxFee is below the floor", () => {
+    // Use Optimism (0xa): its priority-tip floor is 0, so the tip check can
+    // never fire and 'maxFee' is isolated. baseFee 100 -> dynamic floor 110
+    // gwei; dApp 50 gwei is below it.
+    const w = buildFeeWarning({
+      chainId: '0xa',
+      baseFeeWei: gwei(100),
+      dappMaxFeePerGas: hex(gwei(50)),
+      dappMaxPriorityFeePerGas: hex(gwei(1)),
+      oracleMaxFeePerGas: null,
+      oracleMaxPriorityFeePerGas: null,
+    });
+    expect(w).not.toBeNull();
+    expect(w!.trigger).toBe('maxFee');
+    expect(w!.chainId).toBe('0xa');
+  });
+
+  it("flags 'tip' when maxFee is fine but the effective tip is below the floor", () => {
+    const w = buildFeeWarning({
+      ...ethOk,
+      // maxFee 60 gwei is fine; tip 0.1 gwei is below the 1 gwei eth floor.
+      dappMaxFeePerGas: hex(gwei(60)),
+      dappMaxPriorityFeePerGas: hex(GWEI / 10n),
+    });
+    expect(w).not.toBeNull();
+    expect(w!.trigger).toBe('tip');
+  });
+
+  it("flags 'both' when maxFee and tip are both too low", () => {
+    const w = buildFeeWarning({
+      ...ethOk,
+      dappMaxFeePerGas: hex(gwei(10)), // < 22 gwei floor
+      dappMaxPriorityFeePerGas: hex(GWEI / 10n), // < 1 gwei tip floor
+    });
+    expect(w).not.toBeNull();
+    expect(w!.trigger).toBe('both');
+  });
+
+  it('caps the effective tip at (maxFee - baseFee) per EIP-1559', () => {
+    // High stated priority (5 gwei) but maxFee only 0.5 gwei above baseFee,
+    // so miners only ever see ~0.5 gwei -> tip floor (1 gwei) is tripped.
+    const w = buildFeeWarning({
+      chainId: '0x1',
+      baseFeeWei: gwei(20),
+      dappMaxFeePerGas: hex(gwei(20) + GWEI / 2n), // baseFee + 0.5 gwei
+      dappMaxPriorityFeePerGas: hex(gwei(5)),
+      oracleMaxFeePerGas: gwei(45),
+      oracleMaxPriorityFeePerGas: gwei(2),
+    });
+    expect(w).not.toBeNull();
+    // effectiveTip = min(5 gwei, 0.5 gwei) = 0.5 gwei
+    expect(toBigInt(w!.effectiveTipWei)).toBe(GWEI / 2n);
+  });
+
+  // Regression guard for the PR #55 "tip headroom hole": the values the
+  // wallet recommends ('suggested') must themselves clear both floors, or
+  // the user picks "use suggested" and trips the exact same warning again.
+  it('produces a suggestion that does not re-trip the warning (PR #55 invariant)', () => {
+    const scenarios = [
+      // Low maxFee + low tip on Ethereum
+      {
+        chainId: '0x1',
+        baseFeeWei: gwei(30),
+        dappMaxFeePerGas: hex(gwei(12)),
+        dappMaxPriorityFeePerGas: hex(GWEI / 20n),
+      },
+      // Polygon, where the priority floor (25 gwei) is unusually high
+      {
+        chainId: '0x89',
+        baseFeeWei: gwei(40),
+        dappMaxFeePerGas: hex(gwei(35)),
+        dappMaxPriorityFeePerGas: hex(gwei(1)),
+      },
+      // Tight maxFee just above base fee
+      {
+        chainId: '0x1',
+        baseFeeWei: gwei(50),
+        dappMaxFeePerGas: hex(gwei(51)),
+        dappMaxPriorityFeePerGas: hex(GWEI / 10n),
+      },
+    ];
+
+    const label = (s: object) => JSON.stringify(s, (_k, v) => (typeof v === 'bigint' ? v.toString() : v));
+    for (const s of scenarios) {
+      const w = buildFeeWarning({
+        ...s,
+        oracleMaxFeePerGas: null,
+        oracleMaxPriorityFeePerGas: null,
+      });
+      expect(w, `expected a warning for ${label(s)}`).not.toBeNull();
+
+      // Feed the wallet's own suggestion back in as if it were the dApp's
+      // fees. It must clear both floors -> no second warning.
+      const rechecked = buildFeeWarning({
+        chainId: s.chainId,
+        baseFeeWei: toBigInt(w!.baseFeeWei),
+        dappMaxFeePerGas: w!.suggestedMaxFeePerGas,
+        dappMaxPriorityFeePerGas: w!.suggestedMaxPriorityFeePerGas,
+        oracleMaxFeePerGas: null,
+        oracleMaxPriorityFeePerGas: null,
+      });
+      expect(rechecked, `suggestion re-tripped the warning for ${label(s)}`).toBeNull();
+    }
+  });
+
+  it('never silently 10xs the dApp fee: suggestion stays bounded', () => {
+    const w = buildFeeWarning({
+      chainId: '0x1',
+      baseFeeWei: gwei(20),
+      dappMaxFeePerGas: hex(gwei(10)),
+      dappMaxPriorityFeePerGas: hex(GWEI / 10n),
+      oracleMaxFeePerGas: null,
+      oracleMaxPriorityFeePerGas: null,
+    });
+    expect(w).not.toBeNull();
+    // baseFee*2 + suggestedPriority is the formula; with a 1 gwei priority
+    // floor that is 41 gwei — comfortably under 10x the 10 gwei dApp value
+    // would be 100 gwei, so the bound holds.
+    const suggested = toBigInt(w!.suggestedMaxFeePerGas)!;
+    expect(suggested).toBeLessThan(gwei(100));
+    expect(suggested).toBeGreaterThanOrEqual(toBigInt(w!.floorWei)!);
+  });
+});

--- a/chrome-extension/src/background/chains/lastResortRpcs.test.ts
+++ b/chrome-extension/src/background/chains/lastResortRpcs.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { getLastResortRpcs } from './lastResortRpcs';
+
+describe('getLastResortRpcs', () => {
+  it('returns the configured fallback URLs for a known chain', () => {
+    const eth = getLastResortRpcs('eip155:1');
+    expect(eth.length).toBeGreaterThan(0);
+    expect(eth.every(u => u.startsWith('https://'))).toBe(true);
+  });
+
+  it('returns an empty list for an unknown chain', () => {
+    expect(getLastResortRpcs('eip155:999999')).toEqual([]);
+  });
+
+  it('returns a defensive copy (callers cannot mutate the source table)', () => {
+    const a = getLastResortRpcs('eip155:1');
+    const originalLength = a.length;
+    a.push('https://evil.example');
+    const b = getLastResortRpcs('eip155:1');
+    expect(b).toHaveLength(originalLength);
+    expect(b).not.toContain('https://evil.example');
+  });
+
+  it('uses caip-2 (eip155:N) network ids, not bare hex chainIds', () => {
+    // Guards against a caller passing "0x1" and silently getting no fallback.
+    expect(getLastResortRpcs('0x1')).toEqual([]);
+    expect(getLastResortRpcs('eip155:1').length).toBeGreaterThan(0);
+  });
+
+  it('lists no endpoint that requires an API key (per module contract)', () => {
+    for (const id of ['eip155:1', 'eip155:10', 'eip155:137', 'eip155:42161']) {
+      for (const url of getLastResortRpcs(id)) {
+        expect(url).not.toMatch(/(api[_-]?key|\/v[0-9]+\/[A-Za-z0-9]{20,})/i);
+      }
+    }
+  });
+});

--- a/chrome-extension/src/background/spamFilter.test.ts
+++ b/chrome-extension/src/background/spamFilter.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { detectSpamToken, filterSpamTokens, KNOWN_STABLECOINS, type TokenBalanceEntry } from './spamFilter';
+
+const clean: TokenBalanceEntry = {
+  symbol: 'LINK',
+  name: 'Chainlink',
+  balance: '10',
+  valueUsd: '150',
+  priceUsd: '15',
+  caip: 'eip155:1/erc20:0x514910771af9ca656af840dff83e8264ecf986ca',
+};
+
+describe('detectSpamToken — user override (tier 0)', () => {
+  it('treats a "visible" override as not-spam regardless of heuristics', () => {
+    const phishing: TokenBalanceEntry = { symbol: 'X', name: 'claim reward at evil.com', valueUsd: '0' };
+    const r = detectSpamToken(phishing, 'visible');
+    expect(r.isSpam).toBe(false);
+  });
+
+  it('treats a "hidden" override as confirmed spam regardless of legitimacy', () => {
+    const r = detectSpamToken(clean, 'hidden');
+    expect(r).toMatchObject({ isSpam: true, level: 'confirmed' });
+  });
+});
+
+describe('detectSpamToken — confirmed spam', () => {
+  it('flags URL-shaped names as phishing', () => {
+    const r = detectSpamToken({ symbol: 'AIR', name: 'visit airdrop.xyz', valueUsd: '5' });
+    expect(r).toMatchObject({ isSpam: true, level: 'confirmed' });
+  });
+
+  it('flags a URL in the symbol field too', () => {
+    const r = detectSpamToken({ symbol: 'www.x.io', name: 'Token', valueUsd: '5' });
+    expect(r.level).toBe('confirmed');
+  });
+
+  it('flags phishing keywords in the name', () => {
+    for (const name of ['Claim your bonus', 'FREE gift', 'redeem voucher']) {
+      expect(detectSpamToken({ symbol: 'TKN', name, valueUsd: '100' }).level).toBe('confirmed');
+    }
+  });
+
+  it('flags suspicious symbol characters', () => {
+    const r = detectSpamToken({ symbol: 'US$DT', name: 'Tether', valueUsd: '100' });
+    expect(r.level).toBe('confirmed');
+  });
+
+  it('flags an over-long symbol (> 11 chars)', () => {
+    const r = detectSpamToken({ symbol: 'ABCDEFGHIJKL', name: 'Token', valueUsd: '100' });
+    expect(r.level).toBe('confirmed');
+  });
+
+  it('flags a fake stablecoin trading far from $1', () => {
+    const r = detectSpamToken({ symbol: 'USDC', name: 'USD Coin', valueUsd: '0.01' });
+    expect(r.level).toBe('confirmed');
+    expect(r.reason).toContain('Fake');
+  });
+
+  it('flags a dust airdrop (huge quantity, near-zero unit price)', () => {
+    const r = detectSpamToken({
+      symbol: 'SCAM',
+      name: 'Scam',
+      balance: '5000000',
+      priceUsd: '0.00001',
+      valueUsd: '50',
+    });
+    expect(r.level).toBe('confirmed');
+    expect(r.reason).toContain('Dust airdrop');
+  });
+
+  it('flags large quantity + $0 price but non-zero value (manipulated)', () => {
+    const r = detectSpamToken({ symbol: 'WEIRD', name: 'Weird', balance: '50000', priceUsd: '0', valueUsd: '20' });
+    expect(r.level).toBe('confirmed');
+  });
+});
+
+describe('detectSpamToken — possible spam and clean', () => {
+  it('marks low-value (< $1) tokens as POSSIBLE (not confirmed) spam', () => {
+    const r = detectSpamToken({ symbol: 'TINY', name: 'Tiny Token', balance: '1', priceUsd: '0.5', valueUsd: '0.5' });
+    expect(r).toMatchObject({ isSpam: true, level: 'possible' });
+  });
+
+  it('passes a legitimate, valuable token', () => {
+    const r = detectSpamToken(clean);
+    expect(r).toMatchObject({ isSpam: false, level: null });
+  });
+
+  it('does not apply the dust heuristic to known-legit symbols', () => {
+    // Large SHIB balance at a tiny unit price is normal, not a dust airdrop.
+    const r = detectSpamToken({
+      symbol: 'SHIB',
+      name: 'Shiba Inu',
+      balance: '50000000',
+      priceUsd: '0.00002',
+      valueUsd: '1000',
+    });
+    expect(r.isSpam).toBe(false);
+  });
+
+  it('exposes a non-empty stablecoin allow-list', () => {
+    expect(KNOWN_STABLECOINS).toContain('USDT');
+    expect(KNOWN_STABLECOINS).toContain('DAI');
+  });
+});
+
+describe('filterSpamTokens', () => {
+  it('drops confirmed spam but keeps possible spam and clean tokens', () => {
+    const confirmed: TokenBalanceEntry = { symbol: 'X', name: 'claim at evil.io', valueUsd: '0', caip: 'a' };
+    const possible: TokenBalanceEntry = {
+      symbol: 'TINY',
+      name: 'Tiny',
+      valueUsd: '0.5',
+      priceUsd: '0.5',
+      balance: '1',
+      caip: 'b',
+    };
+    const out = filterSpamTokens([clean, confirmed, possible]);
+    const caips = out.map(t => t.caip);
+    expect(caips).toContain(clean.caip);
+    expect(caips).toContain('b'); // possible spam kept
+    expect(caips).not.toContain('a'); // confirmed spam dropped
+  });
+
+  it('always keeps native balances even if they would look like spam', () => {
+    const nativeDust: TokenBalanceEntry = { symbol: 'ETH', name: 'Ethereum', isNative: true, valueUsd: '0' };
+    const out = filterSpamTokens([nativeDust]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('honors a user "visible" override against the confirmed-spam heuristic', () => {
+    const phishing: TokenBalanceEntry = {
+      symbol: 'X',
+      name: 'claim at evil.io',
+      valueUsd: '0',
+      caip: 'eip155:1/erc20:0xABC',
+    };
+    const overrides = new Map([['eip155:1/erc20:0xabc', 'visible' as const]]);
+    const out = filterSpamTokens([phishing], overrides);
+    expect(out).toHaveLength(1);
+  });
+});

--- a/chrome-extension/src/background/utils.test.ts
+++ b/chrome-extension/src/background/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { createProviderRpcError, createTimeoutError, formatUserError } from './utils';
+
+describe('createProviderRpcError', () => {
+  it('sets the code and message', () => {
+    const e = createProviderRpcError(4001, 'User rejected');
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(4001);
+    expect(e.message).toBe('User rejected');
+  });
+
+  it('attaches data and kind only when provided', () => {
+    const bare = createProviderRpcError(4001, 'x');
+    expect(bare.data).toBeUndefined();
+    expect(bare.kind).toBeUndefined();
+
+    const full = createProviderRpcError(-32603, 'y', { detail: 1 }, 'timeout');
+    expect(full.data).toEqual({ detail: 1 });
+    expect(full.kind).toBe('timeout');
+  });
+});
+
+describe('createTimeoutError', () => {
+  it('uses the internal-error code and tags kind=timeout', () => {
+    const e = createTimeoutError('Device did not respond');
+    expect(e.code).toBe(-32603);
+    expect(e.kind).toBe('timeout');
+    expect(e.message).toBe('Device did not respond');
+  });
+});
+
+describe('formatUserError', () => {
+  it('translates the vault "No device connected" error into a friendly message', () => {
+    const e = new Error('SdkError: No device connected');
+    expect(formatUserError(e)).toBe('Please connect your KeepKey device and try again.');
+  });
+
+  it('passes other error messages through unchanged', () => {
+    expect(formatUserError(new Error('replacement transaction underpriced'))).toBe(
+      'replacement transaction underpriced',
+    );
+  });
+
+  it('handles non-Error values by stringifying them', () => {
+    expect(formatUserError('plain string failure')).toBe('plain string failure');
+  });
+
+  it('does not throw on null/undefined input', () => {
+    expect(() => formatUserError(null)).not.toThrow();
+    expect(() => formatUserError(undefined)).not.toThrow();
+  });
+});

--- a/chrome-extension/src/background/utxoDerive.test.ts
+++ b/chrome-extension/src/background/utxoDerive.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { deriveUtxoAddress } from './utxoDerive';
+
+// Canonical BIP test vectors for the "abandon abandon ... about" mnemonic.
+// These pin our local pubkey→address derivation against the published
+// specs — a wrong address here means funds sent to the wrong place, so
+// these assertions are deliberately exact.
+const BTC = 'bip122:000000000019d6689c085ae165831e93/slip44:0';
+
+// BIP84 account 0 (m/84'/0'/0'), receive m/0/0 -> bc1qcr8te4...
+const ZPUB_BIP84 =
+  'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs';
+// BIP44 account 0 (m/44'/0'/0'), receive m/0/0 -> 1LqBGSK...
+const XPUB_BIP44 =
+  'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj';
+
+describe('deriveUtxoAddress — Bitcoin (canonical BIP vectors)', () => {
+  // The BIP84 native-segwit vector is the canonical anchor: the address
+  // below is published in the BIP84 spec, so an exact match proves the
+  // whole pipeline (HDKey parse, version-byte rewrite, hash160, bech32).
+  it('derives the BIP84 native-segwit (p2wpkh) first receive address', () => {
+    const addr = deriveUtxoAddress({ xpub: ZPUB_BIP84, scriptType: 'p2wpkh', networkId: BTC });
+    expect(addr).toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+  });
+
+  it('produces address-format prefixes matching the script type', () => {
+    expect(deriveUtxoAddress({ xpub: ZPUB_BIP84, scriptType: 'p2wpkh', networkId: BTC })).toMatch(/^bc1q/);
+    expect(deriveUtxoAddress({ xpub: XPUB_BIP44, scriptType: 'p2pkh', networkId: BTC })).toMatch(/^1/);
+    expect(deriveUtxoAddress({ xpub: XPUB_BIP44, scriptType: 'p2sh-p2wpkh', networkId: BTC })).toMatch(/^3/);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const a = deriveUtxoAddress({ xpub: ZPUB_BIP84, scriptType: 'p2wpkh', networkId: BTC });
+    const b = deriveUtxoAddress({ xpub: ZPUB_BIP84, scriptType: 'p2wpkh', networkId: BTC });
+    expect(a).toBe(b);
+  });
+
+  it('defaults to p2pkh when no script type is given', () => {
+    const explicit = deriveUtxoAddress({ xpub: XPUB_BIP44, scriptType: 'p2pkh', networkId: BTC });
+    const defaulted = deriveUtxoAddress({ xpub: XPUB_BIP44, networkId: BTC });
+    expect(defaulted).toBe(explicit);
+  });
+});
+
+describe('deriveUtxoAddress — error handling', () => {
+  it('throws on an unsupported networkId', () => {
+    expect(() => deriveUtxoAddress({ xpub: XPUB_BIP44, scriptType: 'p2pkh', networkId: 'eip155:1' })).toThrow(
+      /Unsupported UTXO networkId/,
+    );
+  });
+
+  it('throws on an unsupported script type', () => {
+    expect(() => deriveUtxoAddress({ xpub: XPUB_BIP44, scriptType: 'p2tr', networkId: BTC })).toThrow(
+      /Unsupported script type/,
+    );
+  });
+
+  it('throws on a malformed extended key', () => {
+    expect(() => deriveUtxoAddress({ xpub: 'not-an-xpub', scriptType: 'p2pkh', networkId: BTC })).toThrow();
+  });
+});

--- a/chrome-extension/vitest.config.mts
+++ b/chrome-extension/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit-test runner for the background service-worker logic. Scope is the
+// pure, money-path modules first (fee floors, RPC failover classification,
+// chain config) — the code that decides what gets signed and broadcast.
+// `node` environment: these units have no DOM/chrome.* dependency. Tests
+// that need to mock chrome.* or fetch declare their own stubs per-file.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    // Keep the e2e (WebdriverIO) specs out of the unit runner.
+    exclude: ['**/node_modules/**', '**/dist/**'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "e2e": "pnpm build && pnpm zip && turbo e2e",
     "e2e:firefox": "pnpm build:firefox && pnpm zip:firefox && cross-env __FIREFOX__=true turbo e2e",
     "type-check": "turbo type-check",
+    "test": "turbo test",
     "lint": "turbo lint --continue -- --fix --cache --cache-location node_modules/.cache/.eslintcache",
     "lint:fix": "turbo lint:fix --continue -- --fix --cache --cache-location node_modules/.cache/.eslintcache",
     "prettier": "turbo prettier --continue -- --cache --cache-location node_modules/.cache/.prettiercache",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.4(typescript@5.5.4)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.23.1))
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.7.5)(terser@5.44.0)
 
   packages/dev-utils:
     devDependencies:
@@ -1876,17 +1879,40 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@wallet-standard/base@1.1.0':
     resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
@@ -2186,6 +2212,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -2316,6 +2346,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2353,6 +2387,10 @@ packages:
   canvas-confetti@1.9.3:
     resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2372,6 +2410,10 @@ packages:
 
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -2967,6 +3009,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2997,6 +3042,10 @@ packages:
   exit-hook@4.0.0:
     resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
     engines: {node: '>=18'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect-webdriverio@5.4.2:
     resolution: {integrity: sha512-7bc5I2dU3onKJaRhBdxKh/C+W+ot7R+RcRMCLTSR7cbfHM9Shk8ocbNDVvjrxaBdA52kbZONVSyhexp7cq2xNA==}
@@ -3810,6 +3859,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -4143,6 +4195,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -4650,6 +4706,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4725,6 +4784,12 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4895,12 +4960,26 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -5152,6 +5231,11 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.3:
     resolution: {integrity: sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -5181,6 +5265,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   wait-port@1.1.0:
@@ -5271,6 +5380,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -6528,6 +6642,21 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.3(@types/node@22.7.5)(terser@5.44.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.18
+    optionalDependencies:
+      vite: 5.4.3(@types/node@22.7.5)(terser@5.44.0)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -6535,6 +6664,11 @@ snapshots:
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -6547,6 +6681,16 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.18
       pathe: 2.0.3
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@wallet-standard/base@1.1.0': {}
 
@@ -6992,6 +7136,8 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.13.4:
@@ -7112,6 +7258,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -7143,6 +7291,14 @@ snapshots:
 
   canvas-confetti@1.9.3: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -7157,6 +7313,8 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   chardet@2.1.0: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -7998,6 +8156,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   ethers@6.15.0:
@@ -8047,6 +8209,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   exit-hook@4.0.0: {}
+
+  expect-type@1.3.0: {}
 
   expect-webdriverio@5.4.2(@wdio/globals@9.17.0)(@wdio/logger@9.18.0)(webdriverio@9.19.2):
     dependencies:
@@ -8914,6 +9078,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -9260,6 +9426,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -9833,6 +10001,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
@@ -9900,6 +10070,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -10134,9 +10308,17 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
   tinyrainbow@1.2.0: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10383,6 +10565,24 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vite-node@2.1.9(@types/node@22.7.5)(terser@5.44.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.3(@types/node@22.7.5)(terser@5.44.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.3(@types/node@20.19.13)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
@@ -10402,6 +10602,41 @@ snapshots:
       '@types/node': 22.7.5
       fsevents: 2.3.3
       terser: 5.44.0
+
+  vitest@2.1.9(@types/node@22.7.5)(terser@5.44.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.3(@types/node@22.7.5)(terser@5.44.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.1(supports-color@8.1.1)
+      expect-type: 1.3.0
+      magic-string: 0.30.18
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.3(@types/node@22.7.5)(terser@5.44.0)
+      vite-node: 2.1.9(@types/node@22.7.5)(terser@5.44.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.7.5
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   wait-port@1.1.0:
     dependencies:
@@ -10574,6 +10809,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,9 @@
     "type-check": {
       "cache": false
     },
+    "test": {
+      "cache": false
+    },
     "lint": {
       "cache": false
     },


### PR DESCRIPTION
## What & why

First step of a broader hardening pass. The extension currently ships with **zero unit tests** — the declared `vitest run` script in `chrome-extension` had no `vitest` installed, and the only existing tests are thin WebdriverIO page-load smoke specs that explicitly skip the signing path. The money paths (signing, fees, derivation, broadcast) are untested.

This PR stands up the harness and covers the **pure, highest-stakes background modules** first.

## Changes

- Add `vitest@^2.1.9` to `chrome-extension` (aligned to the repo's Vite 5), a `vitest.config.mts`, a `test` Turborepo task, and root `pnpm test`.
- **No production behavior changes** — tests only + config.

## Coverage (59 tests, all green)

| Module | Tests | Highlights |
|---|---|---|
| `feeFloors.ts` | 23 | Regression guard for the **PR #55 "tip headroom" hole** (the wallet's own suggested fees must never re-trip the warning); EIP-1559 effective-tip cap; static vs dynamic floors |
| `spamFilter.ts` | 17 | Scam/phishing detection tiers, native-always-kept, possible-vs-confirmed, user-override precedence |
| `utxoDerive.ts` | 7 | Receive-address derivation pinned to the **canonical BIP84 spec vector**; script-type prefixes; error handling |
| `lastResortRpcs.ts` | 5 | Broadcast-fallback table contract (caip-2 ids, defensive copy, no API-key URLs) |
| `utils.ts` | 7 | User-facing error formatting |

Run with `pnpm test` (root) or `pnpm -F chrome-extension test`.

## Deferred (follow-ups)

- Modules importing workspace packages (`@extension/shared`, `@extension/storage`) — e.g. `chainConfig.ts`, `rpcFailover.ts` — need vitest workspace-package resolution/mocking set up first.
- Wiring `test` (and a `type-check`) job into CI on PRs to `develop`. Note: `pnpm type-check` is currently red on `develop` (pre-existing `TS18028` in `src/injected/solana-*.ts`) and should be fixed before a type-check gate is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)