### PR TITLE
test: rpcFailover + chainConfig coverage (vitest workspace resolution)

### DIFF
--- a/chrome-extension/src/background/chainConfig.test.ts
+++ b/chrome-extension/src/background/chainConfig.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { bip32ToAddressNList, getDefaultPaths } from './chainConfig';
+
+const HARDENED = 0x80000000;
+
+describe('bip32ToAddressNList', () => {
+  it("converts a full hardened+non-hardened path (ETH m/44'/60'/0'/0/0)", () => {
+    expect(bip32ToAddressNList("m/44'/60'/0'/0/0")).toEqual([HARDENED + 44, HARDENED + 60, HARDENED + 0, 0, 0]);
+  });
+
+  it("treats 'h' and 'H' as hardened, equivalent to the apostrophe", () => {
+    expect(bip32ToAddressNList("m/84'/0'/0'")).toEqual(bip32ToAddressNList('m/84h/0h/0h'));
+    expect(bip32ToAddressNList('m/84H/0H/0H')).toEqual([HARDENED + 84, HARDENED + 0, HARDENED + 0]);
+  });
+
+  it('parses a path without the leading m/', () => {
+    expect(bip32ToAddressNList("44'/0'/0'")).toEqual([HARDENED + 44, HARDENED + 0, HARDENED + 0]);
+  });
+
+  it('returns an empty list for the master path', () => {
+    expect(bip32ToAddressNList('m/')).toEqual([]);
+  });
+
+  it('does not harden plain (non-suffixed) indices', () => {
+    expect(bip32ToAddressNList('m/0/1/2')).toEqual([0, 1, 2]);
+  });
+});
+
+describe('getDefaultPaths', () => {
+  it('returns a non-empty set of derivation paths', () => {
+    expect(getDefaultPaths().length).toBeGreaterThan(0);
+  });
+
+  it("includes the standard ETH path m/44'/60'/0'", () => {
+    const eth = getDefaultPaths().find(p => p.networks.includes('eip155:1'));
+    expect(eth?.addressNList).toEqual([HARDENED + 44, HARDENED + 60, HARDENED + 0]);
+  });
+
+  it('maps each BIP standard to the right purpose index for Bitcoin scripts', () => {
+    const btc = getDefaultPaths().filter(p => p.networks.includes('bip122:000000000019d6689c085ae165831e93'));
+    const purpose = (scriptType: string) => btc.find(p => p.script_type === scriptType)!.addressNList[0] - HARDENED;
+    expect(purpose('p2pkh')).toBe(44); // BIP44 legacy
+    expect(purpose('p2sh-p2wpkh')).toBe(49); // BIP49 wrapped segwit
+    expect(purpose('p2wpkh')).toBe(84); // BIP84 native segwit
+  });
+
+  it('keeps addressNListMaster prefixed by the account-level addressNList', () => {
+    for (const p of getDefaultPaths()) {
+      expect(p.addressNListMaster.length).toBeGreaterThanOrEqual(p.addressNList.length);
+      expect(p.addressNListMaster.slice(0, p.addressNList.length)).toEqual(p.addressNList);
+    }
+  });
+});

--- a/chrome-extension/src/background/chains/rpcFailover.test.ts
+++ b/chrome-extension/src/background/chains/rpcFailover.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// rpcFailover imports three workspace/sibling modules. Mock them so the unit
+// under test runs in node without pulling the storage/polyfill chain. The
+// `op` callback we pass into withRpcFailoverByNetworkId is fully under our
+// control, so we drive success/failure per URL from the test itself.
+const getBlockchainData = vi.fn();
+const getChainInfo = vi.fn();
+const getLastResortRpcs = vi.fn();
+
+vi.mock('@extension/storage', () => ({
+  blockchainDataStorage: { getBlockchainData: (...a: unknown[]) => getBlockchainData(...a) },
+}));
+vi.mock('./registry', () => ({
+  getChainInfo: (...a: unknown[]) => getChainInfo(...a),
+  // makeStaticProvider just needs to return an identifiable stub; the test's
+  // `op` receives (provider, url) and keys its behavior off `url`.
+  makeStaticProvider: (url: string) => ({ __url: url }),
+}));
+vi.mock('./lastResortRpcs', () => ({
+  getLastResortRpcs: (...a: unknown[]) => getLastResortRpcs(...a),
+}));
+
+import { withRpcFailoverByNetworkId, isTransientRpcError } from './rpcFailover';
+
+describe('isTransientRpcError', () => {
+  it('classifies rate-limit / throttle / 429 as transient', () => {
+    expect(isTransientRpcError('rate limit exceeded')).toBe(true);
+    expect(isTransientRpcError('Request throttled')).toBe(true);
+    expect(isTransientRpcError('HTTP 429 Too Many Requests')).toBe(true);
+  });
+
+  it('classifies timeouts and connection resets as transient', () => {
+    expect(isTransientRpcError('timeout of 5000ms exceeded')).toBe(true);
+    expect(isTransientRpcError('ECONNRESET')).toBe(true);
+    expect(isTransientRpcError('ETIMEDOUT')).toBe(true);
+  });
+
+  it('classifies 5xx server errors as transient', () => {
+    expect(isTransientRpcError('Bad Gateway 502')).toBe(true);
+    expect(isTransientRpcError('503 Service Unavailable')).toBe(true);
+  });
+
+  it('treats definitive RPC errors (revert / invalid params) as NOT transient', () => {
+    expect(isTransientRpcError('execution reverted')).toBe(false);
+    expect(isTransientRpcError('invalid params')).toBe(false);
+    expect(isTransientRpcError('nonce too low')).toBe(false);
+  });
+});
+
+describe('withRpcFailoverByNetworkId', () => {
+  // Use a fresh networkId + URLs per test so the module-level cooldown map
+  // never bleeds between cases.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBlockchainData.mockResolvedValue(null);
+    getChainInfo.mockResolvedValue(null);
+    getLastResortRpcs.mockReturnValue([]);
+  });
+
+  it('returns the result from the first working URL', async () => {
+    getChainInfo.mockResolvedValue({ rpcs: ['https://a.test/1', 'https://b.test/1'] });
+    const op = vi.fn().mockResolvedValue('ok');
+    const result = await withRpcFailoverByNetworkId('eip155:test1', op);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails over to the next URL on a transient error', async () => {
+    getChainInfo.mockResolvedValue({ rpcs: ['https://a.test/2', 'https://b.test/2'] });
+    const op = vi.fn(async (_p: unknown, url: string) => {
+      if (url.includes('a.test')) throw new Error('rate limit exceeded');
+      return 'second';
+    });
+    const result = await withRpcFailoverByNetworkId('eip155:test2', op);
+    expect(result).toBe('second');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT fail over on a definitive error — it rethrows immediately', async () => {
+    getChainInfo.mockResolvedValue({ rpcs: ['https://a.test/3', 'https://b.test/3'] });
+    const op = vi.fn(async () => {
+      throw new Error('execution reverted');
+    });
+    await expect(withRpcFailoverByNetworkId('eip155:test3', op)).rejects.toThrow(/reverted/);
+    expect(op).toHaveBeenCalledTimes(1); // second URL never tried
+  });
+
+  it('throws after every candidate fails transiently', async () => {
+    getChainInfo.mockResolvedValue({ rpcs: ['https://a.test/4', 'https://b.test/4'] });
+    const op = vi.fn(async () => {
+      throw new Error('503 server_error');
+    });
+    await expect(withRpcFailoverByNetworkId('eip155:test4', op)).rejects.toThrow();
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when there are no candidate URLs at all', async () => {
+    const op = vi.fn();
+    await expect(withRpcFailoverByNetworkId('eip155:test5', op)).rejects.toThrow(/No RPC URLs available/);
+    expect(op).not.toHaveBeenCalled();
+  });
+
+  it('orders candidates custom-first, then pioneer, then last-resort, deduped', async () => {
+    getBlockchainData.mockResolvedValue({ providers: ['https://custom.test', 'https://shared.test'] });
+    getChainInfo.mockResolvedValue({ rpcs: ['https://shared.test', 'https://pioneer.test'] });
+    getLastResortRpcs.mockReturnValue(['https://lastresort.test']);
+    const seen: string[] = [];
+    const op = vi.fn(async (_p: unknown, url: string) => {
+      seen.push(url);
+      throw new Error('timeout'); // force it to walk the whole list
+    });
+    await expect(withRpcFailoverByNetworkId('eip155:test6', op)).rejects.toThrow();
+    expect(seen).toEqual([
+      'https://custom.test',
+      'https://shared.test', // deduped — appears once despite being in both lists
+      'https://pioneer.test',
+      'https://lastresort.test',
+    ]);
+  });
+});

--- a/chrome-extension/src/background/chains/rpcFailover.ts
+++ b/chrome-extension/src/background/chains/rpcFailover.ts
@@ -30,7 +30,7 @@ const FAILED_RPC_COOLDOWN_MS = 60_000;
 // blocking the other.
 const failedRpcs = new Map<string, number>();
 
-const isTransientRpcError = (errMsg: string): boolean => {
+export const isTransientRpcError = (errMsg: string): boolean => {
   const m = errMsg.toLowerCase();
   return (
     m.includes('rate limit') ||

--- a/chrome-extension/vitest.config.mts
+++ b/chrome-extension/vitest.config.mts
@@ -1,15 +1,27 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 // Unit-test runner for the background service-worker logic. Scope is the
-// pure, money-path modules first (fee floors, RPC failover classification,
-// chain config) — the code that decides what gets signed and broadcast.
-// `node` environment: these units have no DOM/chrome.* dependency. Tests
-// that need to mock chrome.* or fetch declare their own stubs per-file.
+// pure, money-path modules first (fee floors, RPC failover, chain config) —
+// the code that decides what gets signed and broadcast. `node` environment:
+// these units have no DOM dependency. Tests that exercise modules importing
+// chrome.* (via @extension/*) mock those imports with `vi.mock` per-file.
+const fromHere = (p: string) => fileURLToPath(new URL(p, import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    // The workspace packages declare `main: ./dist/index.js`, which isn't
+    // built during tests. Point at their TS source so vitest can resolve
+    // the imports. Modules whose real source touches browser globals are
+    // additionally `vi.mock`-ed at the top of the test that imports them.
+    alias: {
+      '@extension/storage': fromHere('../packages/storage/index.ts'),
+      '@extension/shared': fromHere('../packages/shared/index.ts'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
-    // Keep the e2e (WebdriverIO) specs out of the unit runner.
     exclude: ['**/node_modules/**', '**/dist/**'],
   },
 });


### PR DESCRIPTION
## What & why

Follow-up to #69. Unlocks testing of modules that import the `@extension/*` workspace packages, then covers the **RPC failover** path (which decides whether a failed call fails over or surfaces an error) and **BIP32 path / default-derivation** config.

## Changes

- **vitest workspace resolution**: alias `@extension/storage` and `@extension/shared` to their TS source in `vitest.config.mts` (their `package.json` `main` points at an unbuilt `./dist`). Modules whose real source touches browser globals are additionally `vi.mock`-ed per test.
- **rpcFailover.ts (10 tests)** — `export` the transient-vs-definitive classifier and test it (rate-limit/throttle/429/timeout/5xx → transient; revert/invalid-params → definitive). Cover `withRpcFailoverByNetworkId`: first-URL success, fail-over on transient error, **immediate rethrow on definitive error (no wasted retries)**, exhaustion, no-candidates, and `custom → pioneer → last-resort` dedup ordering.
- **chainConfig.ts (9 tests)** — `bip32ToAddressNList` hardening/parse rules; `getDefaultPaths` BIP44/49/84 purpose-index mapping and master-path prefix invariant.

## Notes

- Only production change is adding `export` to `isTransientRpcError` (additive; no behavior change).
- 78 tests total now green (`pnpm -F chrome-extension test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)