### PR TITLE
ci: run unit tests on PRs (gate on develop)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --prefer-offline
+
+      - run: pnpm test


### PR DESCRIPTION
## What & why

First CI **correctness gate**. Runs the vitest suite (added in #69) on every PR and on pushes to `main`/`develop`. Mirrors the existing `lint.yml` (pnpm + `setup-node` from `.nvmrc` + `--frozen-lockfile`).

The `pull_request:` trigger has no branch filter, so it runs on PRs into `develop` — where active work lands. (Note: several existing workflows, e.g. `e2e.yml`, only trigger on `main`; worth aligning to `develop` in a follow-up.)

## Scope

- Adds `.github/workflows/test.yml` only. No source changes.
- `pnpm test` is green (`turbo test` → chrome-extension vitest).

## Deferred: type-check gate

A `type-check` job is intentionally **not** in this PR. `pnpm type-check` currently surfaces ~13 real, pre-existing type errors in `chrome-extension` (`background/index.ts`, `wallet.ts` — null-safety, `unknown` error handling, object-shape mismatches, a `sidePanel.open` missing `windowId`) plus a missing `target` in the shared tsconfig (`#private` fields need ES2015+). Those are real fixes in sensitive background code and belong in their own reviewed PR before the gate is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)