### PR TITLE
feat(networks): "Show Testnets" toggle (Sepolia, Base Sepolia, Solana Devnet)

### DIFF
--- a/chrome-extension/src/background/chains/solanaHandler.ts
+++ b/chrome-extension/src/background/chains/solanaHandler.ts
@@ -1,4 +1,5 @@
-import { requestStorage, accountsByNetworkStorage } from '@extension/storage';
+import { requestStorage, accountsByNetworkStorage, assetContextStorage } from '@extension/storage';
+import { SOLANA_DEVNET } from '../testnetPresets';
 import { v4 as uuidv4 } from 'uuid';
 import * as wallet from '../wallet';
 import { createProviderRpcError, createTimeoutError } from '../utils';
@@ -8,10 +9,23 @@ const TAG = ' | solanaHandler | ';
 
 // Vault REST API and Solana mainnet RPC
 const VAULT_URL = 'http://localhost:1646';
-const SOLANA_RPC_URLS = [
+const SOLANA_MAINNET_RPC_URLS = [
   'https://api.mainnet-beta.solana.com',
   'https://mainnet.helius-rpc.com/?api-key=1d8740dc-e5f4-421c-b823-e1bad1889eff',
 ];
+
+// Pick the cluster's RPC list from the active asset context. When the user
+// has Solana Devnet selected, sign/broadcast must hit devnet — otherwise a
+// devnet tx silently fails on mainnet. Defaults to mainnet.
+async function getSolanaRpcUrls(): Promise<string[]> {
+  try {
+    const ctx = await assetContextStorage.get();
+    if ((ctx as any)?.networkId === SOLANA_DEVNET.networkId) return SOLANA_DEVNET.rpcs;
+  } catch {
+    /* fall through to mainnet */
+  }
+  return SOLANA_MAINNET_RPC_URLS;
+}
 
 let cachedRpcUrl: string | null = null;
 let cachedRpcTimestamp = 0;
@@ -19,10 +33,14 @@ const RPC_CACHE_TTL = 60000; // cache healthy RPC for 60s
 
 async function getSolanaRpcUrl(): Promise<string> {
   const now = Date.now();
+  const urls = await getSolanaRpcUrls();
+  // Invalidate the cache if it points at a URL outside the active cluster
+  // (e.g. user just switched mainnet <-> devnet).
+  if (cachedRpcUrl && !urls.includes(cachedRpcUrl)) cachedRpcUrl = null;
   if (cachedRpcUrl && now - cachedRpcTimestamp < RPC_CACHE_TTL) {
     return cachedRpcUrl;
   }
-  for (const url of SOLANA_RPC_URLS) {
+  for (const url of urls) {
     try {
       const resp = await fetch(url, {
         method: 'POST',
@@ -39,7 +57,7 @@ async function getSolanaRpcUrl(): Promise<string> {
       /* try next */
     }
   }
-  return SOLANA_RPC_URLS[0]; // fallback to primary
+  return urls[0]; // fallback to primary
 }
 
 // Cached addresses keyed by BIP44 account index (m/44'/501'/<index>'/0').
@@ -646,7 +664,7 @@ function classifySolanaBroadcastError(msg: string): SolanaBroadcastErrorKind {
  * Broadcast a signed Solana transaction via Solana JSON-RPC.
  * Vault has NO broadcast endpoint — we send directly to Solana RPC.
  *
- * Iterates SOLANA_RPC_URLS on transient failures. Health-checked URLs
+ * Iterates the active cluster's RPC URLs on transient failures. Health-checked URLs
  * sometimes pass `getHealth` but reject `sendTransaction` (rate-limit,
  * regional throttling), so the failover loop reaches further than the
  * pre-flight selection in `getSolanaRpcUrl`.
@@ -655,7 +673,8 @@ async function broadcastTransaction(signedTxBase64: string): Promise<string> {
   const errors: { url: string; error: string }[] = [];
   // Try the cached/healthy URL first, then any others not yet attempted.
   const primary = await getSolanaRpcUrl();
-  const ordered = [primary, ...SOLANA_RPC_URLS.filter(u => u !== primary)];
+  const clusterUrls = await getSolanaRpcUrls();
+  const ordered = [primary, ...clusterUrls.filter(u => u !== primary)];
 
   for (const rpcUrl of ordered) {
     let response: Response;

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -35,9 +35,11 @@ import {
   ethAccountsStorage,
   accountsByNetworkStorage,
   customEvmNetworksStorage,
+  testnetSettingsStorage,
 } from '@extension/storage';
-import { getChainInfo, makeStaticProvider } from './chains/registry';
+import { getChainInfo } from './chains/registry';
 import { withRpcFailoverByNetworkId } from './chains/rpcFailover';
+import { EVM_TESTNETS, SOLANA_DEVNET } from './testnetPresets';
 import { formatUserError } from './utils';
 import { filterSpamTokens } from './spamFilter';
 
@@ -507,11 +509,11 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
             if (!chainData?.providerUrl) continue;
 
             try {
-              const rpcProvider = makeStaticProvider(chainData.providerUrl, networkId);
-              const rawBal = await Promise.race([
-                rpcProvider.getBalance(evmAddress),
-                new Promise<bigint>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
-              ]);
+              // Use the failover stack so every URL in providers[] is
+              // tried, not just providerUrl — testnets ship multiple RPCs.
+              const rawBal = await withRpcFailoverByNetworkId(networkId, p => p.getBalance(evmAddress), {
+                timeoutMs: 5000,
+              });
               const balStr = (Number(rawBal) / 1e18).toString();
               const caip = chainData.caip || `${networkId}/slip44:60`;
               balances.push({
@@ -529,6 +531,42 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
               console.log(`[fetchBalances] RPC balance for ${chainData.name}: ${balStr}`);
             } catch (e: any) {
               console.warn(`[fetchBalances] RPC balance failed for ${networkId}:`, e.message);
+            }
+          }
+
+          // Solana devnet: Pioneer only indexes mainnet, so fetch the
+          // devnet native balance directly. Same address works on every
+          // cluster. Best-effort — failure just leaves it absent.
+          const savedChainsSet = new Set(savedChains || []);
+          if (savedChainsSet.has(SOLANA_DEVNET.networkId) && !coveredNetworks.has(SOLANA_DEVNET.networkId)) {
+            const solAddr = allPubkeys.find((pk: any) =>
+              (pk.networks || []).some((n: string) => n.startsWith('solana:')),
+            )?.address;
+            if (solAddr) {
+              try {
+                const resp = await fetch(SOLANA_DEVNET.rpcs[0], {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getBalance', params: [solAddr] }),
+                  signal: AbortSignal.timeout(5000),
+                });
+                const json = await resp.json();
+                const lamports = json?.result?.value ?? 0;
+                balances.push({
+                  networkId: SOLANA_DEVNET.networkId,
+                  caip: SOLANA_DEVNET.caip,
+                  symbol: SOLANA_DEVNET.symbol,
+                  name: SOLANA_DEVNET.name,
+                  balance: (lamports / 1e9).toString(),
+                  valueUsd: '0',
+                  priceUsd: '0',
+                  isNative: true,
+                  address: solAddr,
+                });
+                console.log(`[fetchBalances] Solana devnet balance: ${lamports / 1e9}`);
+              } catch (e: any) {
+                console.warn('[fetchBalances] Solana devnet balance failed:', e.message);
+              }
             }
           }
         }
@@ -1551,6 +1589,95 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
           } catch (error) {
             console.error('Error removing custom EVM network:', error);
             sendResponse({ error: 'Failed to remove custom EVM network' });
+          }
+          break;
+        }
+
+        case 'GET_TESTNETS_ENABLED': {
+          try {
+            const enabled = await testnetSettingsStorage.getShowTestnets();
+            sendResponse({ enabled });
+          } catch (error) {
+            sendResponse({ enabled: false });
+          }
+          break;
+        }
+
+        case 'SET_TESTNETS_ENABLED': {
+          const enabled = !!message.enabled;
+          try {
+            await testnetSettingsStorage.setShowTestnets(enabled);
+
+            if (enabled) {
+              // EVM testnets: register exactly like a user-added custom
+              // network so the header dropdown + balance enrichment +
+              // rpcFailover all pick them up. providers[] carries every
+              // public RPC so failover has fallbacks.
+              for (const t of EVM_TESTNETS) {
+                await customEvmNetworksStorage.addNetwork({
+                  networkId: t.networkId,
+                  chainId: t.chainId,
+                  name: t.name,
+                  rpc: t.rpcs[0],
+                  symbol: t.symbol,
+                  explorerUrl: t.explorerUrl,
+                });
+                await blockchainDataStorage.addBlockchainData(t.networkId, {
+                  chainId: '0x' + t.chainId.toString(16),
+                  caip: `${t.networkId}/slip44:60`,
+                  name: t.name,
+                  symbol: t.symbol,
+                  explorer: t.explorerUrl,
+                  explorerAddressLink: `${t.explorerUrl}/address/`,
+                  explorerTxLink: `${t.explorerUrl}/tx/`,
+                  blockExplorerUrls: [t.explorerUrl],
+                  providerUrl: t.rpcs[0],
+                  providers: t.rpcs,
+                  nativeCurrency: { name: t.symbol, symbol: t.symbol, decimals: 18 },
+                  type: 'evm',
+                  isTestnet: true,
+                } as any);
+                await blockchainStorage.addBlockchain(t.networkId);
+              }
+              // Solana devnet: register in the chain storages. RPC routing
+              // is handled by solanaHandler when this network is selected.
+              await blockchainDataStorage.addBlockchainData(SOLANA_DEVNET.networkId, {
+                caip: SOLANA_DEVNET.caip,
+                name: SOLANA_DEVNET.name,
+                symbol: SOLANA_DEVNET.symbol,
+                explorer: SOLANA_DEVNET.explorerUrl,
+                providerUrl: SOLANA_DEVNET.rpcs[0],
+                providers: SOLANA_DEVNET.rpcs,
+                nativeCurrency: { name: SOLANA_DEVNET.symbol, symbol: SOLANA_DEVNET.symbol, decimals: 9 },
+                type: 'solana',
+                isTestnet: true,
+              } as any);
+              await blockchainStorage.addBlockchain(SOLANA_DEVNET.networkId);
+            } else {
+              const ids = [...EVM_TESTNETS.map(t => t.networkId), SOLANA_DEVNET.networkId];
+              for (const id of ids) {
+                await customEvmNetworksStorage.removeNetwork(id).catch(() => {});
+                await blockchainStorage.removeBlockchain(id);
+                await blockchainDataStorage.set((prev: any) => {
+                  if (!prev || !(id in prev)) return prev || {};
+                  const next = { ...prev };
+                  delete next[id];
+                  return next;
+                });
+                // Drop asset context if it points at a removed testnet.
+                const currentCtx = await assetContextStorage.get().catch(() => null);
+                if ((currentCtx as any)?.networkId === id) {
+                  await assetContextStorage.clearContext().catch(() => {});
+                  chrome.runtime.sendMessage({ type: 'ASSET_CONTEXT_CLEARED' }).catch(() => {});
+                }
+              }
+            }
+
+            const networks = await customEvmNetworksStorage.getNetworks();
+            sendResponse({ success: true, enabled, networks });
+          } catch (error) {
+            console.error('Error toggling testnets:', error);
+            sendResponse({ error: 'Failed to toggle testnets' });
           }
           break;
         }

--- a/chrome-extension/src/background/testnetPresets.ts
+++ b/chrome-extension/src/background/testnetPresets.ts
@@ -1,0 +1,58 @@
+// Default testnet definitions, toggled on/off via the "Show testnets"
+// setting. Each carries multiple public RPCs so the failover stack
+// (rpcFailover.ts for EVM, solanaHandler for Solana) has fallbacks.
+// RPCs verified reachable + correct chainId on 2026-06-22.
+//
+// ponytail: hardcoded RPCs are a deliberate exception here — testnets
+// are NOT in Pioneer's registry, so there's no source-of-truth to defer
+// to. If Pioneer ever indexes them, drop these and let registry win.
+
+export type EvmTestnet = {
+  networkId: string;
+  chainId: number;
+  name: string;
+  symbol: string;
+  explorerUrl: string;
+  rpcs: string[];
+};
+
+export type SolanaTestnet = {
+  networkId: string;
+  caip: string;
+  name: string;
+  symbol: string;
+  explorerUrl: string;
+  rpcs: string[];
+};
+
+export const EVM_TESTNETS: EvmTestnet[] = [
+  {
+    networkId: 'eip155:11155111',
+    chainId: 11155111,
+    name: 'Ethereum Sepolia',
+    symbol: 'ETH',
+    explorerUrl: 'https://sepolia.etherscan.io',
+    rpcs: ['https://ethereum-sepolia-rpc.publicnode.com', 'https://1rpc.io/sepolia'],
+  },
+  {
+    networkId: 'eip155:84532',
+    chainId: 84532,
+    name: 'Base Sepolia',
+    symbol: 'ETH',
+    explorerUrl: 'https://sepolia.basescan.org',
+    rpcs: ['https://sepolia.base.org', 'https://base-sepolia-rpc.publicnode.com'],
+  },
+];
+
+// CAIP-2 solana reference = first 32 chars of the base58 genesis hash.
+// Devnet genesis: EtWTRABZaYq6iMfeYKA7Kzv3HTKFbW7Rsv7zMxj2z9Y
+export const SOLANA_DEVNET: SolanaTestnet = {
+  networkId: 'solana:EtWTRABZaYq6iMfeYKA7Kzv3HTKFbW7R',
+  caip: 'solana:EtWTRABZaYq6iMfeYKA7Kzv3HTKFbW7R/slip44:501',
+  name: 'Solana Devnet',
+  symbol: 'SOL',
+  explorerUrl: 'https://explorer.solana.com/?cluster=devnet',
+  rpcs: ['https://api.devnet.solana.com'],
+};
+
+export const ALL_TESTNET_NETWORK_IDS = [...EVM_TESTNETS.map(t => t.networkId), SOLANA_DEVNET.networkId];

--- a/packages/storage/lib/customStorage.ts
+++ b/packages/storage/lib/customStorage.ts
@@ -625,6 +625,29 @@ const createCustomEvmNetworksStorage = (): CustomEvmNetworksStorage => {
 
 export const customEvmNetworksStorage = createCustomEvmNetworksStorage();
 
+// ---- Testnet visibility ----
+type TestnetSettingsStorage = BaseStorage<{ showTestnets: boolean }> & {
+  getShowTestnets: () => Promise<boolean>;
+  setShowTestnets: (value: boolean) => Promise<void>;
+};
+
+const createTestnetSettingsStorage = (): TestnetSettingsStorage => {
+  const storage = createStorage<{ showTestnets: boolean }>(
+    'keepkey-testnet-settings',
+    { showTestnets: false },
+    { storageType: StorageType.Local, liveUpdate: true },
+  );
+  return {
+    ...storage,
+    getShowTestnets: async () => (await storage.get())?.showTestnets ?? false,
+    setShowTestnets: async (value: boolean) => {
+      await storage.set(() => ({ showTestnets: value }));
+    },
+  };
+};
+
+export const testnetSettingsStorage = createTestnetSettingsStorage();
+
 // Utility function to move an event between storages
 const moveEvent = async (
   eventId: string,

--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -13,6 +13,7 @@ import {
   ethAccountsStorage,
   accountsByNetworkStorage,
   customEvmNetworksStorage,
+  testnetSettingsStorage,
 } from './customStorage';
 import { chainIdStorage } from './providerStorage';
 import { exampleThemeStorage, exampleSidebarStorage } from './exampleThemeStorage';
@@ -44,6 +45,7 @@ export {
   ethAccountsStorage,
   accountsByNetworkStorage,
   customEvmNetworksStorage,
+  testnetSettingsStorage,
 };
 
 export type { BaseStorage };

--- a/pages/side-panel/src/components/Settings.tsx
+++ b/pages/side-panel/src/components/Settings.tsx
@@ -13,6 +13,7 @@ import {
   web3ProviderStorage,
   customEvmNetworksStorage,
   ethAccountsStorage,
+  testnetSettingsStorage,
 } from '@extension/storage';
 
 const TAG = ' | Settings | ';
@@ -25,6 +26,7 @@ const Settings = () => {
     enableKeplrMasking: false,
     enablePhantomMasking: false,
   });
+  const [showTestnets, setShowTestnets] = useState(false);
 
   // Fetch initial masking settings from storage
   useEffect(() => {
@@ -40,10 +42,30 @@ const Settings = () => {
         enableKeplrMasking: keplrSetting,
         enablePhantomMasking: phantomSetting,
       });
+
+      const testnetSetting = await testnetSettingsStorage.getShowTestnets();
+      setShowTestnets(testnetSetting);
     };
 
     loadSettings();
   }, []);
+
+  const toggleTestnets = async () => {
+    const newValue = !showTestnets;
+    setShowTestnets(newValue); // optimistic
+    chrome.runtime.sendMessage({ type: 'SET_TESTNETS_ENABLED', enabled: newValue }, response => {
+      if (response?.success) {
+        toast({
+          title: newValue ? 'Testnets added' : 'Testnets removed',
+          status: 'success',
+          duration: 2000,
+        });
+      } else {
+        setShowTestnets(!newValue); // revert
+        toast({ title: 'Failed to toggle testnets', description: response?.error, status: 'error', duration: 3000 });
+      }
+    });
+  };
 
   // Toggle functions
   const toggleMetaMaskMasking = async () => {
@@ -195,6 +217,19 @@ const Settings = () => {
       <Image src="/kk.gif" alt="KeepKey" />
 
       <VStack spacing={4} align="stretch">
+        <Text fontSize="md" fontWeight="bold">
+          Networks
+        </Text>
+
+        {/* Show Testnets */}
+        <HStack w="100%" justifyContent="space-between">
+          <Text>Show Testnets</Text>
+          <Switch size="md" isChecked={showTestnets} onChange={toggleTestnets} />
+        </HStack>
+        <Text fontSize="xs" color="whiteAlpha.700" mt={-2} mb={2}>
+          Adds Ethereum Sepolia, Base Sepolia, and Solana Devnet with default public RPCs. Turning off removes them.
+        </Text>
+
         <Text fontSize="md" fontWeight="bold">
           Enable Masking
         </Text>


### PR DESCRIPTION
## What

Adds a **Settings → Networks → "Show Testnets"** toggle. When on, it registers three testnets with default public RPCs; when off, it removes them.

| Network | networkId | RPCs (failover order) |
|---|---|---|
| Ethereum Sepolia | `eip155:11155111` | `ethereum-sepolia-rpc.publicnode.com`, `1rpc.io/sepolia` |
| Base Sepolia | `eip155:84532` | `sepolia.base.org`, `base-sepolia-rpc.publicnode.com` |
| Solana Devnet | `solana:EtWTRABZaYq6iMfeYKA7Kzv3HTKFbW7R` | `api.devnet.solana.com` |

All endpoints verified reachable + correct chainId on 2026-06-22.

## How

- **Source of truth:** `chrome-extension/src/background/testnetPresets.ts` — one list, multiple RPCs per chain.
- **Toggle:** `testnetSettingsStorage` (persisted bool) + `SET_TESTNETS_ENABLED` / `GET_TESTNETS_ENABLED` background handlers. EVM testnets register exactly like a user-added custom network (custom + blockchainData + blockchain storages) so the header dropdown, balance enrichment, and rpcFailover all pick them up.
- **Fallback fix:** balance enrichment now goes through `withRpcFailoverByNetworkId`, so every URL in `providers[]` is tried (previously only `providerUrl`). This is also the fix for the silent-`Failed to fetch` case.
- **Solana devnet:** registered in chain storages; `solanaHandler` routes sign/broadcast to the devnet cluster when the devnet network is the active asset context; devnet native balance is fetched directly (Pioneer only indexes mainnet).

## Scope / follow-ups

- EVM testnets are **fully functional** (appear in dropdown, balance via failover, sends via failover).
- Solana devnet is registered + RPC-routed + balance-fetched, but **needs device-on-devnet testing**, and surfacing it as a selectable dropdown row may need a tweak to `buildNetworkRows` (mainnet Solana comes from pubkeys, not custom storage).
- Hardcoded testnet RPCs are a deliberate exception (testnets aren't in Pioneer's registry) — documented with a `ponytail:` comment. Drop them if Pioneer ever indexes testnets.

## Test

1. Settings → toggle **Show Testnets** on.
2. Fund a Sepolia / Base Sepolia address → balance appears (was \$0 before).
3. Toggle off → all three removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)