### PR TITLE
feat: portfolio data layer + durable scam suppression (EPIC-5 + EPIC-6)

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -289,6 +289,56 @@ let tokenDiscoveryDone = false;
 // (not for calls that return the in-flight dedup promise).
 let latestFetchId = 0;
 
+// ---- Last-good portfolio persistence (chrome.storage.local) ----
+// Hydrate cached balances at worker start so the dashboard shows real numbers
+// immediately after MV3 evicts the service worker, instead of a $0 flash.
+// Scoped to a fingerprint of the active wallet's pubkeys so a different device —
+// or a different passphrase wallet on the same device — never shows the previous
+// wallet's balances (the GET_APP_BALANCES guard drops a hydrated cache whose
+// fingerprint doesn't match the connected wallet).
+const PORTFOLIO_CACHE_KEY = 'keepkey-portfolio-cache';
+let portfolioUpdatedAt = 0;
+let cacheFromHydrate = false;
+let hydratedFingerprint: string | null = null;
+
+function walletFingerprint(): string {
+  const pks = wallet.getPubkeys();
+  if (!pks.length) return '';
+  const addrs = pks
+    .map((p: any) => p.address || p.master || p.pubkey || '')
+    .filter(Boolean)
+    .sort();
+  let h = 0;
+  const s = addrs.join('|');
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return String(h);
+}
+
+function persistPortfolio(balances: any[]) {
+  portfolioUpdatedAt = Date.now();
+  chrome.storage.local
+    .set({ [PORTFOLIO_CACHE_KEY]: { fingerprint: walletFingerprint(), balances, updatedAt: portfolioUpdatedAt } })
+    .catch(() => {});
+}
+
+// Kicked once at worker start. GET_APP_BALANCES awaits it before reading the
+// cache so the very first dashboard paint can use last-good data.
+const portfolioHydrated: Promise<void> = (async () => {
+  try {
+    const data = await chrome.storage.local.get(PORTFOLIO_CACHE_KEY);
+    const cached = data[PORTFOLIO_CACHE_KEY];
+    if (cached?.balances?.length && cachedBalances.length === 0) {
+      cachedBalances = cached.balances;
+      portfolioUpdatedAt = cached.updatedAt || 0;
+      hydratedFingerprint = cached.fingerprint || null;
+      cacheFromHydrate = true;
+      console.log(`[portfolio] hydrated ${cachedBalances.length} balances from storage`);
+    }
+  } catch {
+    /* no persisted portfolio — ignore */
+  }
+})();
+
 function pushBalancesUpdated() {
   chrome.runtime.sendMessage({ type: 'BALANCES_UPDATED' }).catch(() => {
     // No popup/sidebar listening — ignore.
@@ -612,6 +662,10 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
       const snapshotStale = currentPubkeyCount > allPubkeys.length;
       if (myFetchId === latestFetchId && !snapshotStale) {
         cachedBalances = balances;
+        // This commit is authoritative for the connected wallet — supersede any
+        // hydrated last-good cache and persist the fresh set for next worker start.
+        cacheFromHydrate = false;
+        persistPortfolio(balances);
         // A forced fetch performs token discovery (ERC-20/SPL/TRC-20); record
         // that so the GET_APP_BALANCES backstop stops re-triggering.
         if (forceRefresh) tokenDiscoveryDone = true;
@@ -1803,6 +1857,20 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
 
         case 'GET_APP_BALANCES': {
           try {
+            await portfolioHydrated;
+            // Drop a hydrated last-good cache that belongs to a different wallet
+            // (different device, or a different passphrase on the same device)
+            // once the connected wallet's pubkeys are known.
+            if (
+              cacheFromHydrate &&
+              wallet.isInitialized() &&
+              hydratedFingerprint &&
+              walletFingerprint() !== hydratedFingerprint
+            ) {
+              cachedBalances = [];
+              cacheFromHydrate = false;
+              hydratedFingerprint = null;
+            }
             if (cachedBalances.length > 0) {
               // Backstop for the "empty tokens until manual Refresh" bug: a
               // non-empty cache that holds only natives (no token rows) means
@@ -1815,7 +1883,7 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               // force-refresh when one isn't already running, and stop entirely
               // once a discovery has committed (tokenDiscoveryDone).
               const discovering = !tokenDiscoveryDone && !cachedBalances.some((b: any) => b.token === true);
-              sendResponse({ balances: cachedBalances, discovering });
+              sendResponse({ balances: cachedBalances, discovering, updatedAt: portfolioUpdatedAt });
               if (discovering && !balancesFetchInProgress) {
                 fetchBalancesFromPioneer(true).catch(e => console.warn(tag, 'auto token-discovery failed:', e));
               }

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -426,6 +426,26 @@ async function getCustomTokenCaipSet(): Promise<Set<string>> {
   }
 }
 
+// Re-apply the durable per-token visibility overrides to the in-memory cache
+// WITHOUT a network refetch, by re-partitioning the combined visible+hidden set.
+// So a hide/un-hide is reflected and persisted immediately and survives a failed
+// refetch or MV3 worker restart (the override map is the source of truth, not the
+// last persisted partition).
+async function reconcileVisibility(): Promise<void> {
+  const overrides = await getTokenVisibilityMap();
+  const customCaips = await getCustomTokenCaipSet();
+  const combined = [...cachedBalances, ...hiddenBalances];
+  const { visible, hidden } = partitionSpamTokens(
+    combined,
+    overrides,
+    b => !!b.caip && customCaips.has(String(b.caip).toLowerCase()),
+  );
+  cachedBalances = visible;
+  hiddenBalances = hidden;
+  persistPortfolio(cachedBalances);
+  pushBalancesUpdated();
+}
+
 // All EVM CAPIPs (deduplicated) — used to fan out EVM wildcard addresses
 const EVM_CAIPS = [...new Set(Object.values(shortListSymbolToCaip).filter(caip => caip.startsWith('eip155:')))];
 
@@ -1171,7 +1191,15 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
 
         case 'CLEAR_CACHE': {
           cachedBalances = [];
+          hiddenBalances = [];
           balancesFetchInProgress = null;
+          lastFetchError = null;
+          cacheFromHydrate = false;
+          hydratedFingerprint = null;
+          tokenDiscoveryDone = false;
+          // Also drop the persisted portfolio so a worker restart can't re-hydrate
+          // the stale set we just cleared.
+          chrome.storage.local.remove(PORTFOLIO_CACHE_KEY).catch(() => {});
           sendResponse({ success: true });
           break;
         }
@@ -2031,9 +2059,8 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
         }
 
         case 'SET_TOKEN_VISIBILITY': {
-          // Wire the per-token user override (spamFilter tier-0). Lets a user
-          // permanently hide a scam token (e.g. a fabricated-value 'Mortal' that
-          // passes the value heuristics) or re-show a false positive.
+          // Per-token user override (spamFilter tier-0): permanently hide a scam
+          // token (e.g. a fabricated-value 'Mortal') or re-show a false positive.
           try {
             const { caip, status } = message as { caip?: string; status?: 'visible' | 'hidden' };
             if (!caip || (status !== 'visible' && status !== 'hidden')) {
@@ -2041,15 +2068,12 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               break;
             }
             await setTokenVisibility(caip, status);
-            // Optimistically drop a just-hidden token from the cache so it
-            // disappears immediately everywhere; re-show relies on the refetch.
-            if (status === 'hidden') {
-              cachedBalances = cachedBalances.filter((b: any) => (b.caip?.toLowerCase() || '') !== caip.toLowerCase());
-              pushBalancesUpdated();
-            }
+            // Apply the override to the in-memory set DETERMINISTICALLY (no network):
+            // re-partition + persist + push, so the change is durable immediately
+            // and survives a failed refetch / worker restart.
+            await reconcileVisibility();
             sendResponse({ success: true });
-            // Rebuild from source so the override is reflected consistently
-            // (and brings a re-shown token back). BALANCES_UPDATED repaints.
+            // Freshness only — the override is already applied + persisted above.
             fetchBalancesFromPioneer(true).catch(e => console.warn(tag, 'visibility refresh failed:', e));
           } catch (error: any) {
             console.error(tag, 'SET_TOKEN_VISIBILITY error:', error);

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -42,7 +42,7 @@ import {
 } from '@extension/storage';
 import { getChainInfo } from './chains/registry';
 import { withRpcFailoverByNetworkId } from './chains/rpcFailover';
-import { EVM_TESTNETS, SOLANA_DEVNET } from './testnetPresets';
+import { EVM_TESTNETS, SOLANA_DEVNET, ALL_TESTNET_NETWORK_IDS } from './testnetPresets';
 import { formatUserError } from './utils';
 import { partitionSpamTokens, getTokenVisibilityMap, setTokenVisibility } from './spamFilter';
 
@@ -150,7 +150,12 @@ async function handleDeviceSwitch(newDeviceInfo: any) {
 
   // Balance caches — pubkey-keyed, so they're poisoned by the old device
   cachedBalances = [];
+  hiddenBalances = [];
   balancesFetchInProgress = null;
+  lastFetchError = null;
+  cacheFromHydrate = false;
+  hydratedFingerprint = null;
+  tokenDiscoveryDone = false;
 
   // Per-chain address caches (Solana/Tron/TON each keep their own lookup
   // cache above the pubkey layer)
@@ -317,16 +322,22 @@ function walletFingerprint(): string {
     .map((p: any) => p.address || p.master || p.pubkey || '')
     .filter(Boolean)
     .sort();
-  let h = 0;
-  const s = addrs.join('|');
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
-  return String(h);
+  // Direct content fingerprint of the wallet's address set — no hashing, so no
+  // collision risk for the cross-wallet cache guard.
+  return addrs.join('|');
 }
 
 function persistPortfolio(balances: any[]) {
   portfolioUpdatedAt = Date.now();
   chrome.storage.local
-    .set({ [PORTFOLIO_CACHE_KEY]: { fingerprint: walletFingerprint(), balances, updatedAt: portfolioUpdatedAt } })
+    .set({
+      [PORTFOLIO_CACHE_KEY]: {
+        fingerprint: walletFingerprint(),
+        balances,
+        hidden: hiddenBalances,
+        updatedAt: portfolioUpdatedAt,
+      },
+    })
     .catch(() => {});
 }
 
@@ -338,10 +349,13 @@ const portfolioHydrated: Promise<void> = (async () => {
     const cached = data[PORTFOLIO_CACHE_KEY];
     if (cached?.balances?.length && cachedBalances.length === 0) {
       cachedBalances = cached.balances;
+      hiddenBalances = cached.hidden || [];
       portfolioUpdatedAt = cached.updatedAt || 0;
       hydratedFingerprint = cached.fingerprint || null;
       cacheFromHydrate = true;
-      console.log(`[portfolio] hydrated ${cachedBalances.length} balances from storage`);
+      console.log(
+        `[portfolio] hydrated ${cachedBalances.length} balances (+${hiddenBalances.length} hidden) from storage`,
+      );
     }
   } catch {
     /* no persisted portfolio — ignore */
@@ -374,7 +388,16 @@ function backfillNativePrices(balances: any[]): void {
     if (parseFloat(b.priceUsd || '0') > 0) continue;
     const sym = String(b.symbol || '').toUpperCase();
     let price = b.caip ? priceByCaip.get(b.caip) : undefined;
-    if (!price && b.networkId?.startsWith('eip155:') && sym === 'ETH') price = ethPrice;
+    // Testnets register their native as 'ETH' too — never borrow the real
+    // mainnet price for faucet ETH (would put fake money in the dashboard total).
+    if (
+      !price &&
+      b.networkId?.startsWith('eip155:') &&
+      sym === 'ETH' &&
+      !ALL_TESTNET_NETWORK_IDS.includes(b.networkId)
+    ) {
+      price = ethPrice;
+    }
     if (price) {
       b.priceUsd = price;
       b.valueUsd = (parseFloat(b.balance) * parseFloat(price)).toString();
@@ -709,7 +732,6 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
         b => !!b.caip && customCaips.has(String(b.caip).toLowerCase()),
       );
       balances = visible;
-      hiddenBalances = hidden;
       if (hidden.length > 0) {
         console.log(`[fetchBalances] Spam: ${visible.length} visible, ${hidden.length} hidden of ${preFilterCount}`);
       }
@@ -733,6 +755,9 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
       const snapshotStale = currentPubkeyCount > allPubkeys.length;
       if (myFetchId === latestFetchId && !snapshotStale) {
         cachedBalances = balances;
+        // Adopt the Hidden bucket only on the winning commit (mirrors cachedBalances)
+        // so a superseded fetch can't leave the Hidden section out of sync.
+        hiddenBalances = hidden;
         // This commit is authoritative for the connected wallet — supersede any
         // hydrated last-good cache and persist the fresh set for next worker start.
         cacheFromHydrate = false;
@@ -764,7 +789,9 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
       return balances;
     } catch (e: any) {
       console.error('[fetchBalances] Error:', e.message || e);
-      lastFetchError = e?.message || 'balance fetch failed';
+      // Only the winning fetch may record an error — a superseded/late failure
+      // must not clobber a newer fetch's cleared state.
+      if (myFetchId === latestFetchId) lastFetchError = e?.message || 'balance fetch failed';
       return cachedBalances;
     } finally {
       // Only clear the in-flight ref if WE are still the active fetch — a newer
@@ -1934,12 +1961,9 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             // Drop a hydrated last-good cache that belongs to a different wallet
             // (different device, or a different passphrase on the same device)
             // once the connected wallet's pubkeys are known.
-            if (
-              cacheFromHydrate &&
-              wallet.isInitialized() &&
-              hydratedFingerprint &&
-              walletFingerprint() !== hydratedFingerprint
-            ) {
+            if (cacheFromHydrate && wallet.isInitialized() && walletFingerprint() !== hydratedFingerprint) {
+              // Drop a hydrated cache that doesn't match the connected wallet —
+              // including a legacy entry with no fingerprint (untrusted).
               cachedBalances = [];
               hiddenBalances = [];
               cacheFromHydrate = false;
@@ -2071,7 +2095,13 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             let nativeCached = cachedBalances.find((b: any) => b.networkId === evmNetworkId && b.isNative);
             // Fallback: L2 chains (Base, Arbitrum, Optimism, etc.) use ETH as native gas —
             // if no cached price for this specific chain, use Ethereum mainnet ETH price.
-            if (!nativeCached?.priceUsd && evmNetworkId !== 'eip155:1') {
+            // NOT for testnets — faucet ETH is worthless (and this value is now
+            // written back into the cached/persisted row by the reconcile block below).
+            if (
+              !nativeCached?.priceUsd &&
+              evmNetworkId !== 'eip155:1' &&
+              !ALL_TESTNET_NETWORK_IDS.includes(evmNetworkId)
+            ) {
               nativeCached = cachedBalances.find((b: any) => b.networkId === 'eip155:1' && b.isNative) || nativeCached;
             }
             const priceUsd = parseFloat(nativeCached?.priceUsd || '0');

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -38,12 +38,13 @@ import {
   accountsByNetworkStorage,
   customEvmNetworksStorage,
   testnetSettingsStorage,
+  customTokensStorageApi,
 } from '@extension/storage';
 import { getChainInfo } from './chains/registry';
 import { withRpcFailoverByNetworkId } from './chains/rpcFailover';
 import { EVM_TESTNETS, SOLANA_DEVNET } from './testnetPresets';
 import { formatUserError } from './utils';
-import { filterSpamTokens, getTokenVisibilityMap, setTokenVisibility } from './spamFilter';
+import { partitionSpamTokens, getTokenVisibilityMap, setTokenVisibility } from './spamFilter';
 
 const TAG = ' | background/index.js | ';
 console.log('Background script loaded');
@@ -300,6 +301,14 @@ const PORTFOLIO_CACHE_KEY = 'keepkey-portfolio-cache';
 let portfolioUpdatedAt = 0;
 let cacheFromHydrate = false;
 let hydratedFingerprint: string | null = null;
+// Records the most recent real fetch failure (cleared on success). Surfaced
+// additively on GET_APP_BALANCES so the UI can show "couldn't load — retry"
+// instead of "no assets".
+let lastFetchError: string | null = null;
+// Tokens suppressed by default (the 'Mortal' fabricated-value class) or user-
+// hidden. Kept OUT of cachedBalances so dashboard totals never include scam
+// value; surfaced via GET_HIDDEN_TOKENS for the recoverable "Hidden" section.
+let hiddenBalances: any[] = [];
 
 function walletFingerprint(): string {
   const pks = wallet.getPubkeys();
@@ -343,6 +352,55 @@ function pushBalancesUpdated() {
   chrome.runtime.sendMessage({ type: 'BALANCES_UPDATED' }).catch(() => {
     // No popup/sidebar listening — ignore.
   });
+}
+
+// Borrow USD prices already present in a fetched balances array to fill held
+// natives Pioneer returned at $0 (custom-RPC chains, some L2s). No network calls
+// — display-only (never touches balance/caip/address). L2 gas tokens ARE ETH, so
+// an unpriced EVM ETH native borrows the mainnet ETH price (same as
+// GET_EVM_BALANCE). Anything still unpriced is flagged priceUnavailable so the UI
+// can render '—' instead of a misleading $0.
+function backfillNativePrices(balances: any[]): void {
+  const priceByCaip = new Map<string, string>();
+  for (const b of balances) {
+    if (b.caip && parseFloat(b.priceUsd || '0') > 0) priceByCaip.set(b.caip, b.priceUsd);
+  }
+  const ethPrice = balances.find(
+    (b: any) => b.networkId === 'eip155:1' && b.isNative && parseFloat(b.priceUsd || '0') > 0,
+  )?.priceUsd;
+  for (const b of balances) {
+    if (!b.isNative) continue;
+    if (parseFloat(b.balance || '0') <= 0) continue;
+    if (parseFloat(b.priceUsd || '0') > 0) continue;
+    const sym = String(b.symbol || '').toUpperCase();
+    let price = b.caip ? priceByCaip.get(b.caip) : undefined;
+    if (!price && b.networkId?.startsWith('eip155:') && sym === 'ETH') price = ethPrice;
+    if (price) {
+      b.priceUsd = price;
+      b.valueUsd = (parseFloat(b.balance) * parseFloat(price)).toString();
+    } else {
+      b.priceUnavailable = true;
+    }
+  }
+}
+
+// Lowercased CAIPs of all user-added custom tokens — used to exempt deliberately
+// added tokens from default spam suppression.
+async function getCustomTokenCaipSet(): Promise<Set<string>> {
+  try {
+    const all = await customTokensStorageApi.getAll();
+    const set = new Set<string>();
+    for (const byUser of Object.values(all || {})) {
+      for (const tokens of Object.values(byUser || {})) {
+        for (const t of tokens || []) {
+          if (t?.caip) set.add(String(t.caip).toLowerCase());
+        }
+      }
+    }
+    return set;
+  } catch {
+    return new Set<string>();
+  }
 }
 
 // All EVM CAPIPs (deduplicated) — used to fan out EVM wildcard addresses
@@ -487,9 +545,11 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
             else natives.push(entry);
           }
           console.log(`[fetchBalances] portfolio: ${natives.length} natives, ${tokens.length} tokens`);
+          lastFetchError = null; // a parsed response (even empty) is a success, not an error
           return { balances: natives, tokens };
         } catch (e: any) {
           console.warn('[fetchBalances] portfolio error:', e.message);
+          lastFetchError = e?.message || 'portfolio fetch failed';
           return { balances: [] as any[], tokens: [] as any[] };
         }
       };
@@ -630,17 +690,28 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
         console.warn('[fetchBalances] Custom chain enrichment error:', e.message);
       }
 
+      // Backfill USD prices for held natives Pioneer returned at $0, reusing
+      // prices already in this response (no network call). After custom-chain
+      // enrichment so RPC-derived natives are included.
+      backfillNativePrices(balances);
+
       const preFilterCount = balances.length;
-      // Honor per-token user overrides (spamFilter tier-0): a 'hidden' token is
-      // dropped, a 'visible' one is force-kept. Without this map the override
-      // layer is dead code and scam tokens with a fabricated >=$1 value (e.g.
-      // 'Mortal') have no kill switch.
+      // Spam handling at the single chokepoint: honor per-token user overrides
+      // (tier 0), HARD-DROP confirmed phishing, and route 'Mortal'-class
+      // fabricated-value tokens into a recoverable Hidden bucket (kept OUT of the
+      // cache/totals; surfaced via GET_HIDDEN_TOKENS). User-added custom tokens
+      // are exempt from default suppression.
       const visibilityOverrides = await getTokenVisibilityMap();
-      balances = filterSpamTokens(balances, visibilityOverrides);
-      if (balances.length !== preFilterCount) {
-        console.log(
-          `[fetchBalances] Spam filter dropped ${preFilterCount - balances.length}/${preFilterCount} token entries`,
-        );
+      const customCaips = await getCustomTokenCaipSet();
+      const { visible, hidden } = partitionSpamTokens(
+        balances,
+        visibilityOverrides,
+        b => !!b.caip && customCaips.has(String(b.caip).toLowerCase()),
+      );
+      balances = visible;
+      hiddenBalances = hidden;
+      if (hidden.length > 0) {
+        console.log(`[fetchBalances] Spam: ${visible.length} visible, ${hidden.length} hidden of ${preFilterCount}`);
       }
 
       console.log(
@@ -665,6 +736,7 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
         // This commit is authoritative for the connected wallet — supersede any
         // hydrated last-good cache and persist the fresh set for next worker start.
         cacheFromHydrate = false;
+        lastFetchError = null;
         persistPortfolio(balances);
         // A forced fetch performs token discovery (ERC-20/SPL/TRC-20); record
         // that so the GET_APP_BALANCES backstop stops re-triggering.
@@ -692,6 +764,7 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
       return balances;
     } catch (e: any) {
       console.error('[fetchBalances] Error:', e.message || e);
+      lastFetchError = e?.message || 'balance fetch failed';
       return cachedBalances;
     } finally {
       // Only clear the in-flight ref if WE are still the active fetch — a newer
@@ -1868,8 +1941,10 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               walletFingerprint() !== hydratedFingerprint
             ) {
               cachedBalances = [];
+              hiddenBalances = [];
               cacheFromHydrate = false;
               hydratedFingerprint = null;
+              lastFetchError = null;
             }
             if (cachedBalances.length > 0) {
               // Backstop for the "empty tokens until manual Refresh" bug: a
@@ -1883,7 +1958,12 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               // force-refresh when one isn't already running, and stop entirely
               // once a discovery has committed (tokenDiscoveryDone).
               const discovering = !tokenDiscoveryDone && !cachedBalances.some((b: any) => b.token === true);
-              sendResponse({ balances: cachedBalances, discovering, updatedAt: portfolioUpdatedAt });
+              sendResponse({
+                balances: cachedBalances,
+                discovering,
+                updatedAt: portfolioUpdatedAt,
+                error: lastFetchError || undefined,
+              });
               if (discovering && !balancesFetchInProgress) {
                 fetchBalancesFromPioneer(true).catch(e => console.warn(tag, 'auto token-discovery failed:', e));
               }
@@ -1891,7 +1971,7 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               // Empty cache (fresh worker): force-refresh so the first read
               // discovers tokens too, not just native balances.
               const balances = await fetchBalancesFromPioneer(true);
-              sendResponse({ balances });
+              sendResponse({ balances, error: balances.length === 0 ? lastFetchError || undefined : undefined });
             } else {
               sendResponse({ balances: [] });
             }
@@ -1909,11 +1989,20 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               break;
             }
             const balances = await fetchBalancesFromPioneer(true);
-            sendResponse({ balances });
+            sendResponse({ balances, error: balances.length === 0 ? lastFetchError || undefined : undefined });
           } catch (error: any) {
             console.error(tag, 'REFRESH_ALL_BALANCES error:', error);
             sendResponse({ balances: cachedBalances, error: error.message });
           }
+          break;
+        }
+
+        case 'GET_HIDDEN_TOKENS': {
+          // Tokens suppressed by default or user-hidden — for the recoverable
+          // "Hidden" section in Tokens.tsx. Optional networkId filter.
+          const netFilter = message?.networkId;
+          const rows = netFilter ? hiddenBalances.filter((b: any) => b.networkId === netFilter) : hiddenBalances;
+          sendResponse({ hidden: rows });
           break;
         }
 
@@ -1987,6 +2076,27 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             }
             const priceUsd = parseFloat(nativeCached?.priceUsd || '0');
             const valueUsd = (parseFloat(balStr) * priceUsd).toString();
+
+            // Reconcile: write the fresh live balance back into the matching
+            // cached native row keyed by BOTH networkId AND address. Native rows
+            // are per-account, so matching on address never clobbers another
+            // account's row; the dashboard's per-network SUM stays correct and now
+            // reflects the fresh value. Skip when no row matches (don't synthesize
+            // a row the portfolio fan-out didn't produce — would double-count).
+            const liveRow = cachedBalances.find(
+              (b: any) =>
+                b.isNative &&
+                b.networkId === evmNetworkId &&
+                String(b.address || '').toLowerCase() === evmAddress.toLowerCase(),
+            );
+            if (liveRow) {
+              liveRow.balance = balStr;
+              liveRow.priceUsd = priceUsd.toString();
+              liveRow.valueUsd = valueUsd;
+              delete liveRow.priceUnavailable;
+              persistPortfolio(cachedBalances);
+              pushBalancesUpdated();
+            }
 
             sendResponse({
               balance: balStr,

--- a/chrome-extension/src/background/spamFilter.test.ts
+++ b/chrome-extension/src/background/spamFilter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { detectSpamToken, filterSpamTokens, KNOWN_STABLECOINS, type TokenBalanceEntry } from './spamFilter';
+import {
+  detectSpamToken,
+  filterSpamTokens,
+  partitionSpamTokens,
+  KNOWN_STABLECOINS,
+  type TokenBalanceEntry,
+} from './spamFilter';
 
 const clean: TokenBalanceEntry = {
   symbol: 'LINK',
@@ -50,8 +56,8 @@ describe('detectSpamToken — confirmed spam', () => {
     expect(r.level).toBe('confirmed');
   });
 
-  it('flags a fake stablecoin trading far from $1', () => {
-    const r = detectSpamToken({ symbol: 'USDC', name: 'USD Coin', valueUsd: '0.01' });
+  it('flags a fake stablecoin trading far from $1 (when priced)', () => {
+    const r = detectSpamToken({ symbol: 'USDC', name: 'USD Coin', valueUsd: '0.01', priceUsd: '0.01' });
     expect(r.level).toBe('confirmed');
     expect(r.reason).toContain('Fake');
   });
@@ -139,9 +145,7 @@ describe('filterSpamTokens', () => {
     expect(out).toHaveLength(1);
   });
 
-  it('a "hidden" override kills a token that passes every heuristic (the "Mortal" case)', () => {
-    // A scam token with a benign symbol and a fabricated >=$1 value passes all
-    // heuristic tiers and lands "clean" — only a user override removes it.
+  it('suppresses a benign-symbol fabricated-value token by default (the "Mortal" case), recoverably', () => {
     const mortal: TokenBalanceEntry = {
       symbol: 'MORTAL',
       name: 'Mortal',
@@ -150,12 +154,50 @@ describe('filterSpamTokens', () => {
       balance: '1',
       caip: 'eip155:1/erc20:0xDEAD',
     };
-    // No override → survives (proves the heuristics alone don't catch it).
-    expect(filterSpamTokens([mortal]).map(t => t.caip)).toContain(mortal.caip);
-    // Hidden override → dropped (the kill switch).
-    const hidden = new Map([['eip155:1/erc20:0xdead', 'hidden' as const]]);
-    expect(filterSpamTokens([mortal], hidden)).toHaveLength(0);
-    // Override removed → reappears.
-    expect(filterSpamTokens([mortal], new Map()).map(t => t.caip)).toContain(mortal.caip);
+    // Default: detected 'suppressed' and routed to the recoverable Hidden bucket.
+    expect(detectSpamToken(mortal)).toMatchObject({ isSpam: true, level: 'suppressed' });
+    const def = partitionSpamTokens([mortal]);
+    expect(def.visible).toHaveLength(0);
+    expect(def.hidden.map(t => t.caip)).toContain(mortal.caip);
+    // A 'visible' override un-hides it permanently.
+    const shown = new Map([['eip155:1/erc20:0xdead', 'visible' as const]]);
+    expect(partitionSpamTokens([mortal], shown).visible.map(t => t.caip)).toContain(mortal.caip);
+    // A user-added custom token of the same shape is NOT suppressed.
+    expect(partitionSpamTokens([mortal], undefined, () => true).visible.map(t => t.caip)).toContain(mortal.caip);
+  });
+
+  it('keeps a not-yet-priced legit token (price-aware tiers do not fire at price 0)', () => {
+    const newtkn: TokenBalanceEntry = {
+      symbol: 'NEWTKN',
+      name: 'New Token',
+      balance: '10',
+      priceUsd: '0',
+      valueUsd: '0',
+      caip: 'eip155:1/erc20:0xBEEF',
+    };
+    expect(detectSpamToken(newtkn).isSpam).toBe(false);
+    expect(partitionSpamTokens([newtkn]).visible.map(t => t.caip)).toContain(newtkn.caip);
+  });
+
+  it('hard-drops confirmed phishing but routes suppressed into the Hidden bucket', () => {
+    const phishing: TokenBalanceEntry = { symbol: 'X', name: 'claim at evil.io', valueUsd: '0', caip: 'a' };
+    const mortal: TokenBalanceEntry = {
+      symbol: 'MORTAL',
+      name: 'Mortal',
+      valueUsd: '5',
+      priceUsd: '5',
+      balance: '1',
+      caip: 'b',
+    };
+    const { visible, hidden } = partitionSpamTokens([phishing, mortal]);
+    expect(visible).toHaveLength(0);
+    expect(hidden.map(t => t.caip)).toEqual(['b']); // mortal hidden; phishing hard-dropped
+  });
+
+  it('keeps a native row visible even with $0 value', () => {
+    const nativeDust: TokenBalanceEntry = { symbol: 'ETH', name: 'Ethereum', isNative: true, valueUsd: '0', caip: 'n' };
+    const { visible, hidden } = partitionSpamTokens([nativeDust]);
+    expect(visible).toHaveLength(1);
+    expect(hidden).toHaveLength(0);
   });
 });

--- a/chrome-extension/src/background/spamFilter.test.ts
+++ b/chrome-extension/src/background/spamFilter.test.ts
@@ -149,8 +149,8 @@ describe('filterSpamTokens', () => {
     const mortal: TokenBalanceEntry = {
       symbol: 'MORTAL',
       name: 'Mortal',
-      valueUsd: '5',
-      priceUsd: '5',
+      valueUsd: '5000',
+      priceUsd: '5000',
       balance: '1',
       caip: 'eip155:1/erc20:0xDEAD',
     };
@@ -184,8 +184,8 @@ describe('filterSpamTokens', () => {
     const mortal: TokenBalanceEntry = {
       symbol: 'MORTAL',
       name: 'Mortal',
-      valueUsd: '5',
-      priceUsd: '5',
+      valueUsd: '5000',
+      priceUsd: '5000',
       balance: '1',
       caip: 'b',
     };

--- a/chrome-extension/src/background/spamFilter.test.ts
+++ b/chrome-extension/src/background/spamFilter.test.ts
@@ -145,7 +145,7 @@ describe('filterSpamTokens', () => {
     expect(out).toHaveLength(1);
   });
 
-  it('suppresses a benign-symbol fabricated-value token by default (the "Mortal" case), recoverably', () => {
+  it('shows a high-value benign-symbol token by default; a "hidden" override moves it to the recoverable Hidden bucket', () => {
     const mortal: TokenBalanceEntry = {
       symbol: 'MORTAL',
       name: 'Mortal',
@@ -154,16 +154,17 @@ describe('filterSpamTokens', () => {
       balance: '1',
       caip: 'eip155:1/erc20:0xDEAD',
     };
-    // Default: detected 'suppressed' and routed to the recoverable Hidden bucket.
-    expect(detectSpamToken(mortal)).toMatchObject({ isSpam: true, level: 'suppressed' });
-    const def = partitionSpamTokens([mortal]);
-    expect(def.visible).toHaveLength(0);
-    expect(def.hidden.map(t => t.caip)).toContain(mortal.caip);
-    // A 'visible' override un-hides it permanently.
+    // No value-floor auto-suppression — visible by default (legit funds never auto-vanish).
+    expect(detectSpamToken(mortal).isSpam).toBe(false);
+    expect(partitionSpamTokens([mortal]).visible.map(t => t.caip)).toContain(mortal.caip);
+    // A 'hidden' override (one-click Hide) routes it to the recoverable Hidden bucket.
+    const hidden = new Map([['eip155:1/erc20:0xdead', 'hidden' as const]]);
+    const p = partitionSpamTokens([mortal], hidden);
+    expect(p.visible).toHaveLength(0);
+    expect(p.hidden.map(t => t.caip)).toContain(mortal.caip);
+    // A 'visible' override (un-hide) brings it back, durably.
     const shown = new Map([['eip155:1/erc20:0xdead', 'visible' as const]]);
     expect(partitionSpamTokens([mortal], shown).visible.map(t => t.caip)).toContain(mortal.caip);
-    // A user-added custom token of the same shape is NOT suppressed.
-    expect(partitionSpamTokens([mortal], undefined, () => true).visible.map(t => t.caip)).toContain(mortal.caip);
   });
 
   it('keeps a not-yet-priced legit token (price-aware tiers do not fire at price 0)', () => {
@@ -179,19 +180,23 @@ describe('filterSpamTokens', () => {
     expect(partitionSpamTokens([newtkn]).visible.map(t => t.caip)).toContain(newtkn.caip);
   });
 
-  it('hard-drops confirmed phishing but routes suppressed into the Hidden bucket', () => {
+  it('hard-drops confirmed phishing; a legit high-value token stays visible unless user-hidden', () => {
     const phishing: TokenBalanceEntry = { symbol: 'X', name: 'claim at evil.io', valueUsd: '0', caip: 'a' };
-    const mortal: TokenBalanceEntry = {
-      symbol: 'MORTAL',
-      name: 'Mortal',
+    const legit: TokenBalanceEntry = {
+      symbol: 'GMX',
+      name: 'GMX',
       valueUsd: '5000',
-      priceUsd: '5000',
-      balance: '1',
+      priceUsd: '50',
+      balance: '100',
       caip: 'b',
     };
-    const { visible, hidden } = partitionSpamTokens([phishing, mortal]);
-    expect(visible).toHaveLength(0);
-    expect(hidden.map(t => t.caip)).toEqual(['b']); // mortal hidden; phishing hard-dropped
+    // Phishing dropped; the legit unlisted high-value token stays visible (NOT auto-hidden).
+    expect(partitionSpamTokens([phishing, legit]).visible.map(t => t.caip)).toEqual(['b']);
+    // Only an explicit user 'hidden' override moves the legit token to the Hidden bucket.
+    const overrides = new Map([['b', 'hidden' as const]]);
+    const p = partitionSpamTokens([phishing, legit], overrides);
+    expect(p.visible).toHaveLength(0);
+    expect(p.hidden.map(t => t.caip)).toEqual(['b']);
   });
 
   it('keeps a native row visible even with $0 value', () => {

--- a/chrome-extension/src/background/spamFilter.ts
+++ b/chrome-extension/src/background/spamFilter.ts
@@ -125,8 +125,22 @@ const KNOWN_LEGIT_SYMBOLS = new Set([
   'FOX',
 ]);
 
-export type SpamLevel = 'confirmed' | 'possible' | null;
+export type SpamLevel = 'confirmed' | 'suppressed' | 'possible' | null;
 export type TokenVisibilityStatus = 'visible' | 'hidden';
+
+/** Curated trusted token CAIPs (lowercased) — exempt from default suppression.
+ *  Native assets are already exempt. Seed with blue-chip contracts; extend over time. */
+export const TRUSTED_CAIPS = new Set<string>([
+  'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+  'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+  'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+  'eip155:1/erc20:0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', // WBTC
+  'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+]);
+
+/** A non-allowlisted token reporting at least this USD value is treated as a
+ *  fabricated-value lure ('Mortal' class) and suppressed by default (recoverable). */
+export const SUSPICIOUS_VALUE_FLOOR = 1;
 
 export interface SpamResult {
   isSpam: boolean;
@@ -163,7 +177,11 @@ const MAX_SYMBOL_LENGTH = 11;
 /**
  * Detect whether a token is spam.
  */
-export function detectSpamToken(token: TokenBalanceEntry, userOverride?: TokenVisibilityStatus | null): SpamResult {
+export function detectSpamToken(
+  token: TokenBalanceEntry,
+  userOverride?: TokenVisibilityStatus | null,
+  opts?: { isCustom?: boolean },
+): SpamResult {
   // ── Tier 0: User override — absolute precedence ──────────────────
   if (userOverride === 'visible') {
     return { isSpam: false, level: null, reason: 'User marked as safe' };
@@ -173,6 +191,7 @@ export function detectSpamToken(token: TokenBalanceEntry, userOverride?: TokenVi
   }
 
   const usd = parseFloat(token.valueUsd || '0');
+  const price = parseFloat(token.priceUsd || '0');
   const sym = (token.symbol || '').toUpperCase();
   const name = token.name || '';
 
@@ -204,7 +223,9 @@ export function detectSpamToken(token: TokenBalanceEntry, userOverride?: TokenVi
   }
 
   // ── Tier 4: Fake stablecoin (symbol matches but value way off) ───
-  if (KNOWN_STABLECOINS.includes(sym) && usd < 0.5) {
+  // Price-aware: only when the row carries a real price — a not-yet-priced
+  // legit stablecoin (priceUsd 0) must not be flagged.
+  if (price > 0 && KNOWN_STABLECOINS.includes(sym) && usd < 0.5) {
     return {
       isSpam: true,
       level: 'confirmed',
@@ -235,8 +256,22 @@ export function detectSpamToken(token: TokenBalanceEntry, userOverride?: TokenVi
     }
   }
 
+  // ── Tier 5.5: Non-allowlisted token reporting a fabricated value ──
+  // Benign symbol + a non-trivial USD value, not allowlisted and not a
+  // user-added custom token = the 'Mortal' lure. Suppressed by DEFAULT but
+  // recoverable (routed to the Hidden bucket, never hard-dropped).
+  const caipLc = (token.caip || '').toLowerCase();
+  if (!opts?.isCustom && !KNOWN_LEGIT_SYMBOLS.has(sym) && !TRUSTED_CAIPS.has(caipLc) && usd >= SUSPICIOUS_VALUE_FLOOR) {
+    return {
+      isSpam: true,
+      level: 'suppressed',
+      reason: `Unverified token reporting $${usd.toFixed(2)} — hidden by default (recoverable)`,
+    };
+  }
+
   // ── Tier 6: Low value → POSSIBLE spam ────────────────────────────
-  if (usd < 1) {
+  // Price-aware: a not-yet-priced legit token (priceUsd 0) is not "low value".
+  if (price > 0 && usd < 1) {
     return {
       isSpam: true,
       level: 'possible',
@@ -262,17 +297,67 @@ export function detectSpamToken(token: TokenBalanceEntry, userOverride?: TokenVi
  *
  * Native chain balances are always kept regardless of classification.
  */
+export interface PartitionedBalances {
+  visible: TokenBalanceEntry[];
+  hidden: TokenBalanceEntry[];
+}
+
+/**
+ * Partition balances into inline-visible vs a recoverable "Hidden" bucket:
+ *  - Native rows: always visible.
+ *  - User 'visible' override: always visible (tier 0).
+ *  - User 'hidden' override: Hidden bucket (recoverable).
+ *  - Heuristic 'confirmed' (URL/keyword/suspicious-symbol/fake-stable/dust):
+ *    HARD-DROPPED — phishing must never render, even collapsed.
+ *  - Heuristic 'suppressed' (the 'Mortal' fabricated-value class): Hidden bucket
+ *    (recoverable) — hidden by default, the user can reveal/un-hide it.
+ *  - Otherwise (clean / possible): visible.
+ * Hidden rows are tagged `_hidden` + `_hiddenReason` and kept in the cache.
+ */
+export function partitionSpamTokens(
+  balances: TokenBalanceEntry[],
+  overrides?: Map<string, TokenVisibilityStatus>,
+  isCustom?: (b: TokenBalanceEntry) => boolean,
+): PartitionedBalances {
+  const visible: TokenBalanceEntry[] = [];
+  const hidden: TokenBalanceEntry[] = [];
+  for (const b of balances) {
+    if (b.isNative) {
+      visible.push(b);
+      continue;
+    }
+    const override = overrides?.get(b.caip?.toLowerCase() || '') ?? null;
+    if (override === 'visible') {
+      visible.push(b);
+      continue;
+    }
+    if (override === 'hidden') {
+      hidden.push({ ...b, _hidden: true, _hiddenReason: 'Hidden by you' });
+      continue;
+    }
+    const result = detectSpamToken(b, null, { isCustom: isCustom?.(b) });
+    if (result.level === 'confirmed') {
+      // phishing — hard drop (not shown anywhere)
+      continue;
+    }
+    if (result.level === 'suppressed') {
+      hidden.push({ ...b, _hidden: true, _hiddenReason: result.reason });
+      continue;
+    }
+    visible.push(b);
+  }
+  return { visible, hidden };
+}
+
+/**
+ * Back-compat wrapper: returns only the visible balances. Prefer
+ * partitionSpamTokens when you need the recoverable Hidden bucket.
+ */
 export function filterSpamTokens(
   balances: TokenBalanceEntry[],
   overrides?: Map<string, TokenVisibilityStatus>,
 ): TokenBalanceEntry[] {
-  return balances.filter(b => {
-    if (b.isNative) return true;
-
-    const override = overrides?.get(b.caip?.toLowerCase() || '') ?? null;
-    const result = detectSpamToken(b, override);
-    return !(result.isSpam && result.level === 'confirmed');
-  });
+  return partitionSpamTokens(balances, overrides).visible;
 }
 
 // ── Token visibility persistence (chrome.storage.local) ────────────

--- a/chrome-extension/src/background/spamFilter.ts
+++ b/chrome-extension/src/background/spamFilter.ts
@@ -259,18 +259,12 @@ export function detectSpamToken(
     }
   }
 
-  // ── Tier 5.5: Non-allowlisted token reporting a fabricated value ──
-  // Benign symbol + a non-trivial USD value, not allowlisted and not a
-  // user-added custom token = the 'Mortal' lure. Suppressed by DEFAULT but
-  // recoverable (routed to the Hidden bucket, never hard-dropped).
-  const caipLc = (token.caip || '').toLowerCase();
-  if (!opts?.isCustom && !KNOWN_LEGIT_SYMBOLS.has(sym) && !TRUSTED_CAIPS.has(caipLc) && usd >= SUSPICIOUS_VALUE_FLOOR) {
-    return {
-      isSpam: true,
-      level: 'suppressed',
-      reason: `Unverified token reporting $${usd.toFixed(2)} — hidden by default (recoverable)`,
-    };
-  }
+  // NOTE: there is deliberately NO value-floor auto-suppression. A high USD value
+  // is not evidence of fabrication, and we have no server-side trust signal to
+  // tell a fabricated-value scam from a legit unlisted token — auto-hiding
+  // non-allowlisted tokens would underreport real holdings. The 'Mortal' class is
+  // handled by the per-token user Hide + recoverable Hidden section (a one-click,
+  // durable override) instead.
 
   // ── Tier 6: Low value → POSSIBLE spam ────────────────────────────
   // Price-aware: a not-yet-priced legit token (priceUsd 0) is not "low value".

--- a/chrome-extension/src/background/spamFilter.ts
+++ b/chrome-extension/src/background/spamFilter.ts
@@ -139,8 +139,11 @@ export const TRUSTED_CAIPS = new Set<string>([
 ]);
 
 /** A non-allowlisted token reporting at least this USD value is treated as a
- *  fabricated-value lure ('Mortal' class) and suppressed by default (recoverable). */
-export const SUSPICIOUS_VALUE_FLOOR = 1;
+ *  fabricated-value lure ('Mortal' class) and suppressed by default (recoverable).
+ *  Set HIGH on purpose: only egregiously-large fabricated values are auto-hidden,
+ *  so legit mid-cap holdings stay visible (and counted in the total). Smaller
+ *  scams are still hideable per-row. Tune as the trusted allowlist grows. */
+export const SUSPICIOUS_VALUE_FLOOR = 1000;
 
 export interface SpamResult {
   isSpam: boolean;

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -98,10 +98,14 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
     } else if (asset.networkId) {
       setLoadingAddress(true);
       chrome.runtime.sendMessage({ type: 'GET_PUBKEYS_FOR_NETWORK', networkId: asset.networkId }, response => {
-        if (response?.pubkeys?.[0]) {
-          setAddress(response.pubkeys[0].address || response.pubkeys[0].master || '');
-        }
+        const resolved = response?.pubkeys?.[0]?.address || response?.pubkeys?.[0]?.master || '';
+        if (resolved) setAddress(resolved);
         setLoadingAddress(false);
+        // EVM: refresh the cache for the resolved account so detail + dashboard
+        // stay fresh even when the address was resolved asynchronously here.
+        if (isEvm && resolved) {
+          chrome.runtime.sendMessage({ type: 'GET_EVM_BALANCE', networkId: asset.networkId, address: resolved });
+        }
       });
       return;
     }

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -37,9 +37,6 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
   const [loadingAddress, setLoadingAddress] = useState(false);
   const [events, setEvents] = useState<any[]>([]);
   const [eventsLoading, setEventsLoading] = useState(true);
-  const [liveBalance, setLiveBalance] = useState<number | null>(null);
-  const [liveUsdValue, setLiveUsdValue] = useState<number | null>(null);
-  const [livePriceUsd, setLivePriceUsd] = useState<number | null>(null);
   const toast = useToast();
 
   const isEvm = asset.networkId?.startsWith('eip155:');
@@ -56,21 +53,19 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
   const cachedUsdValue = chainBalances.reduce((sum, b) => sum + parseFloat(b.valueUsd || '0'), 0);
   const cachedPriceUsd = nativeBalances[0] ? parseFloat(nativeBalances[0].priceUsd || '0') : 0;
 
-  // Use live data when available (EVM), fallback to cached
-  const totalBalance = liveBalance !== null ? liveBalance : cachedBalance;
-  const totalUsdValue = liveUsdValue !== null ? liveUsdValue : cachedUsdValue;
-  const priceUsd = livePriceUsd !== null ? livePriceUsd : cachedPriceUsd;
+  // Render from the cached aggregate (sum across accounts) so the detail page
+  // matches the dashboard exactly. GET_EVM_BALANCE still fires below to refresh
+  // the cache (per-account write-back + BALANCES_UPDATED); SidePanel passes the
+  // refreshed balances back down, so this stays fresh AND consistent.
+  const totalBalance = cachedBalance;
+  const totalUsdValue = cachedUsdValue;
+  const priceUsd = cachedPriceUsd;
 
   // Build icon URL
   const iconUrl = asset.icon || `https://api.keepkey.info/coins/${btoa(asset.caip || '').replace(/=+$/, '')}.png`;
 
   // Fetch address and live balance when asset changes
   useEffect(() => {
-    // Reset live balance on asset change
-    setLiveBalance(null);
-    setLiveUsdValue(null);
-    setLivePriceUsd(null);
-
     // UTXO chains: pubkey-list rows have empty .address and Pioneer's
     // /portfolio response stuffs the xpub into b.address (line ~439 in
     // background/index.ts), so falling back to asset.pubkeys[0].address
@@ -111,18 +106,13 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
       return;
     }
 
-    // For EVM chains, fetch fresh balance for the selected account address via RPC
+    // For EVM chains, fire a fresh RPC balance for this account. We don't read
+    // the response — the background writes the live value back into the cached
+    // row (keyed by address) and pushes BALANCES_UPDATED, so SidePanel re-sends
+    // refreshed `balances` down and this page (which renders from the cached
+    // aggregate) updates in lockstep with the dashboard.
     if (isEvm && accountAddress) {
-      chrome.runtime.sendMessage(
-        { type: 'GET_EVM_BALANCE', networkId: asset.networkId, address: accountAddress },
-        response => {
-          if (response && !response.error) {
-            setLiveBalance(parseFloat(response.balance || '0'));
-            setLiveUsdValue(parseFloat(response.valueUsd || '0'));
-            setLivePriceUsd(parseFloat(response.priceUsd || '0'));
-          }
-        },
-      );
+      chrome.runtime.sendMessage({ type: 'GET_EVM_BALANCE', networkId: asset.networkId, address: accountAddress });
     }
   }, [asset.networkId, asset.address, asset.pubkeys?.[0]?.address, asset.note, asset.script_type, isEvm, isUtxo]);
 

--- a/pages/side-panel/src/components/Balances.tsx
+++ b/pages/side-panel/src/components/Balances.tsx
@@ -69,16 +69,25 @@ const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: Ba
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, []);
 
-  // Sort assets by total USD value descending
-  const sortedAssets = [...assets].sort((assetA: any, assetB: any) => {
-    const valueA = balances
-      .filter(bal => bal.networkId === assetA.networkId)
-      .reduce((s, bal) => s + parseFloat(bal.valueUsd || '0'), 0);
-    const valueB = balances
-      .filter(bal => bal.networkId === assetB.networkId)
-      .reduce((s, bal) => s + parseFloat(bal.valueUsd || '0'), 0);
-    return valueB - valueA;
-  });
+  // Drive the dashboard from HOLDINGS, not the full static catalog: a chain
+  // shows only if it has a positive balance (native or token). Keying off the
+  // balance AMOUNT — not USD value — keeps a held asset visible even when its
+  // price is missing/0. The complete catalog stays one tap away via
+  // "+ Add blockchain", so empty chains no longer render as $0.00 rows.
+  const heldNetworkIds = new Set(
+    balances.filter(bal => parseFloat(bal.balance ?? bal.amount ?? '0') > 0).map(bal => bal.networkId),
+  );
+  const sortedAssets = [...assets]
+    .filter((asset: any) => heldNetworkIds.has(asset.networkId))
+    .sort((assetA: any, assetB: any) => {
+      const valueA = balances
+        .filter(bal => bal.networkId === assetA.networkId)
+        .reduce((s, bal) => s + parseFloat(bal.valueUsd || '0'), 0);
+      const valueB = balances
+        .filter(bal => bal.networkId === assetB.networkId)
+        .reduce((s, bal) => s + parseFloat(bal.valueUsd || '0'), 0);
+      return valueB - valueA;
+    });
 
   if (showAddBlockchain) {
     return <AssetSelect setShowAssetSelect={setShowAddBlockchain} />;
@@ -298,10 +307,26 @@ const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: Ba
     <Flex flex="1" overflowY="auto" width="100%" direction="column">
       <Stack width="100%">
         {sortedAssets.length === 0 ? (
-          <Flex justifyContent="center" alignItems="center" width="100%" minH="40vh">
+          <Flex direction="column" justifyContent="center" alignItems="center" gap={4} width="100%" minH="30vh">
             <Text color="kk.faint" fontSize="sm">
-              No assets found
+              No assets yet — receive funds to get started
             </Text>
+            <Flex
+              align="center"
+              justify="center"
+              gap={1.5}
+              px={4}
+              py={2}
+              borderRadius="12px"
+              border="1px dashed"
+              borderColor="kk.line"
+              _hover={{ borderColor: 'kk.lineHi', cursor: 'pointer' }}
+              onClick={() => setShowAddBlockchain(true)}
+              transition="border-color 0.15s">
+              <Text color="kk.faint" fontSize="xs">
+                + Add blockchain
+              </Text>
+            </Flex>
           </Flex>
         ) : (
           <>

--- a/pages/side-panel/src/components/Balances.tsx
+++ b/pages/side-panel/src/components/Balances.tsx
@@ -31,6 +31,7 @@ const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: Ba
   const [balances, setBalances] = useState<any[]>([]);
   const [assets, setAssets] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   const formatBalance = (balance: string) => {
     const numericBalance = parseFloat(balance);
@@ -52,6 +53,7 @@ const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: Ba
     const refreshBalances = () => {
       chrome.runtime.sendMessage({ type: 'GET_APP_BALANCES' }, response => {
         if (response?.balances) setBalances(response.balances);
+        setFetchError(response?.error ?? null);
         setLoading(false);
       });
     };
@@ -88,6 +90,17 @@ const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: Ba
         .reduce((s, bal) => s + parseFloat(bal.valueUsd || '0'), 0);
       return valueB - valueA;
     });
+
+  // Force-refresh after a failed load. REFRESH_ALL_BALANCES bypasses the cache.
+  const retryFetch = () => {
+    setLoading(true);
+    setFetchError(null);
+    chrome.runtime.sendMessage({ type: 'REFRESH_ALL_BALANCES' }, response => {
+      if (response?.balances) setBalances(response.balances);
+      setFetchError(response?.error ?? null);
+      setLoading(false);
+    });
+  };
 
   if (showAddBlockchain) {
     return <AssetSelect setShowAssetSelect={setShowAddBlockchain} />;
@@ -307,27 +320,54 @@ const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: Ba
     <Flex flex="1" overflowY="auto" width="100%" direction="column">
       <Stack width="100%">
         {sortedAssets.length === 0 ? (
-          <Flex direction="column" justifyContent="center" alignItems="center" gap={4} width="100%" minH="30vh">
-            <Text color="kk.faint" fontSize="sm">
-              No assets yet — receive funds to get started
-            </Text>
-            <Flex
-              align="center"
-              justify="center"
-              gap={1.5}
-              px={4}
-              py={2}
-              borderRadius="12px"
-              border="1px dashed"
-              borderColor="kk.line"
-              _hover={{ borderColor: 'kk.lineHi', cursor: 'pointer' }}
-              onClick={() => setShowAddBlockchain(true)}
-              transition="border-color 0.15s">
-              <Text color="kk.faint" fontSize="xs">
-                + Add blockchain
+          fetchError ? (
+            <Flex direction="column" justifyContent="center" alignItems="center" gap={3} width="100%" minH="30vh">
+              <Text color="kk.text" fontSize="sm" fontWeight="medium">
+                Couldn’t load balances
               </Text>
+              <Text color="kk.faint" fontSize="xs" textAlign="center" maxW="240px">
+                {fetchError}
+              </Text>
+              <Flex
+                align="center"
+                justify="center"
+                gap={1.5}
+                px={5}
+                py={2}
+                borderRadius="12px"
+                border="1px solid"
+                borderColor="kk.lineHi"
+                _hover={{ bg: 'kk.surfaceHi', cursor: 'pointer' }}
+                onClick={retryFetch}
+                transition="background 0.15s">
+                <Text color="kk.text" fontSize="xs">
+                  Retry
+                </Text>
+              </Flex>
             </Flex>
-          </Flex>
+          ) : (
+            <Flex direction="column" justifyContent="center" alignItems="center" gap={4} width="100%" minH="30vh">
+              <Text color="kk.faint" fontSize="sm">
+                No assets yet — receive funds to get started
+              </Text>
+              <Flex
+                align="center"
+                justify="center"
+                gap={1.5}
+                px={4}
+                py={2}
+                borderRadius="12px"
+                border="1px dashed"
+                borderColor="kk.line"
+                _hover={{ borderColor: 'kk.lineHi', cursor: 'pointer' }}
+                onClick={() => setShowAddBlockchain(true)}
+                transition="border-color 0.15s">
+                <Text color="kk.faint" fontSize="xs">
+                  + Add blockchain
+                </Text>
+              </Flex>
+            </Flex>
+          )
         ) : (
           <>
             {sortedAssets.map((asset: any, index: number) => {

--- a/pages/side-panel/src/components/Tokens.tsx
+++ b/pages/side-panel/src/components/Tokens.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { VStack, HStack, Box, Text, Spinner, Button, Flex, Badge, IconButton } from '@chakra-ui/react';
-import { FaCoins, FaSync, FaPlus, FaEyeSlash } from 'react-icons/fa';
+import { FaCoins, FaSync, FaPlus, FaEyeSlash, FaEye } from 'react-icons/fa';
 import { customTokensStorageApi, type CustomToken } from '@extension/storage';
 import { CustomTokenDialog } from './CustomTokenDialog';
 import { AssetIcon } from './AssetIcon';
@@ -20,15 +20,21 @@ export const Tokens = ({ asset, networkId }: TokensProps) => {
   // True when the background is discovering tokens (natives present, no tokens
   // yet) — lets us show "Discovering…" instead of a premature "No Tokens Found".
   const [discovering, setDiscovering] = useState(false);
+  const [hiddenTokens, setHiddenTokens] = useState<any[]>([]);
+  const [showHidden, setShowHidden] = useState(false);
 
   useEffect(() => {
     fetchTokens();
+    fetchHidden();
     loadCustomTokens();
     // Refresh token list when background pushes a balance update — otherwise
     // a user viewing the asset detail during a cold-start Solana refetch would
     // see stale "No tokens" after the background lands SPL tokens.
     const listener = (message: any) => {
-      if (message?.type === 'BALANCES_UPDATED') fetchTokens();
+      if (message?.type === 'BALANCES_UPDATED') {
+        fetchTokens();
+        fetchHidden();
+      }
     };
     chrome.runtime.onMessage.addListener(listener);
     return () => chrome.runtime.onMessage.removeListener(listener);
@@ -167,6 +173,30 @@ export const Tokens = ({ asset, networkId }: TokensProps) => {
       if (chrome.runtime.lastError) {
         console.error('Error hiding token:', chrome.runtime.lastError.message);
       }
+    });
+  };
+
+  // Recover a hidden/suppressed token: persist a 'visible' override (tier 0,
+  // absolute precedence) so it returns to the inline list and stays.
+  const handleUnhideToken = (e: React.MouseEvent, token: any) => {
+    e.stopPropagation();
+    if (!token?.caip) return;
+    setHiddenTokens(prev => prev.filter(t => t.caip !== token.caip));
+    chrome.runtime.sendMessage({ type: 'SET_TOKEN_VISIBILITY', caip: token.caip, status: 'visible' }, () => {
+      if (chrome.runtime.lastError) {
+        console.error('Error un-hiding token:', chrome.runtime.lastError.message);
+      }
+    });
+  };
+
+  // Tokens suppressed by default (the 'Mortal' fabricated-value class) or hidden
+  // by the user — for the recoverable "Hidden" section.
+  const fetchHidden = () => {
+    const effectiveNetworkId = networkId || asset?.networkId;
+    chrome.runtime.sendMessage({ type: 'GET_HIDDEN_TOKENS', networkId: effectiveNetworkId }, response => {
+      if (chrome.runtime.lastError) return;
+      const list = (response?.hidden || []).filter((b: any) => parseFloat(b.balance || '0') > 0);
+      setHiddenTokens(list);
     });
   };
 
@@ -473,6 +503,83 @@ export const Tokens = ({ asset, networkId }: TokensProps) => {
             )}
           </HStack>
         </VStack>
+      )}
+
+      {/* Hidden / suppressed tokens — recoverable */}
+      {hiddenTokens.length > 0 && (
+        <Box mt={2}>
+          <Flex
+            align="center"
+            gap={1}
+            cursor="pointer"
+            color="kk.faint"
+            _hover={{ color: 'kk.dim' }}
+            onClick={() => setShowHidden(v => !v)}>
+            <FaEyeSlash size={9} />
+            <Text fontSize="xs" fontWeight="semibold">
+              Hidden ({hiddenTokens.length})
+            </Text>
+            <Text fontSize="2xs">{showHidden ? '▲' : '▼'}</Text>
+          </Flex>
+          {showHidden && (
+            <VStack align="stretch" gap={1} mt={2}>
+              {hiddenTokens.map((token: any, index: number) => {
+                const tokenValueUsd = parseFloat(token.valueUsd || 0);
+                const tokenBalance = parseFloat(token.balance || 0);
+                return (
+                  <Box
+                    key={`hidden-${token.caip}-${index}`}
+                    role="group"
+                    px={2}
+                    py={1.5}
+                    bg="kk.surface"
+                    borderRadius="md"
+                    borderWidth="1px"
+                    borderColor="kk.line"
+                    opacity={0.55}
+                    _hover={{ opacity: 1, bg: 'kk.surfaceHi' }}
+                    transition="opacity 0.15s">
+                    <Flex justify="space-between" align="center">
+                      <HStack gap={2}>
+                        <AssetIcon src={token.icon} symbol={token.symbol} size={28} />
+                        <VStack align="flex-start" gap={0} spacing={0}>
+                          <Text fontSize="xs" fontWeight="semibold" color="kk.text" lineHeight="1.3">
+                            {token.symbol || 'Unknown'}
+                          </Text>
+                          <Text fontSize="2xs" color="kk.faint" lineHeight="1.3" noOfLines={1}>
+                            {token._hiddenReason || token.name || 'Hidden'}
+                          </Text>
+                        </VStack>
+                      </HStack>
+                      <HStack gap={1} align="center">
+                        <VStack align="flex-end" gap={0} spacing={0}>
+                          <Text fontSize="xs" color="kk.dim" fontWeight="medium" lineHeight="1.3">
+                            ${formatUsd(tokenValueUsd)}
+                          </Text>
+                          <Text fontSize="2xs" color="kk.faint" lineHeight="1.3">
+                            {tokenBalance.toFixed(6)} {token.symbol}
+                          </Text>
+                        </VStack>
+                        <IconButton
+                          aria-label="Show token"
+                          title="Un-hide this token"
+                          icon={<FaEye size={11} />}
+                          size="xs"
+                          variant="ghost"
+                          minW="auto"
+                          h="22px"
+                          color="kk.faint"
+                          _hover={{ color: 'kk.accent', bg: 'whiteAlpha.100' }}
+                          onClick={e => handleUnhideToken(e, token)}
+                        />
+                      </HStack>
+                    </Flex>
+                  </Box>
+                );
+              })}
+            </VStack>
+          )}
+        </Box>
       )}
 
       {/* Custom Token Dialog */}


### PR DESCRIPTION
## EPIC-5 (portfolio data layer) + EPIC-6 (token visibility / scam handling)

**Display-only** — `getSendPubkeys`/account scoping and all signing paths are untouched. Passed two adversarial review rounds; all findings fixed.

### EPIC-5 — portfolio data layer
- **Holdings-driven dashboard** — lists only chains with a positive balance (by amount, so price-missing assets still show); full catalog behind "+ Add blockchain".
- **Persisted last-good portfolio** — survives MV3 worker eviction (kills the `$0` flash), scoped to a **wallet-address fingerprint** so a different device / passphrase wallet never shows the prior wallet's balances. Persists the Hidden bucket too.
- **One EVM number** — `GET_EVM_BALANCE` writes the live balance back into the cached native row keyed by **(networkId, address)** (per-account → no cross-account clobber); AssetDetail renders the cached aggregate → detail == dashboard.
- **Price backfill** — held natives Pioneer returned at `$0` borrow a price already in the same response (caip / mainnet-ETH for L2 gas — **never testnets**); else flag `priceUnavailable`. No new endpoints.
- **Error vs empty** — distinct "Couldn't load — Retry" state; never blows away a populated list; genuine-empty wallets aren't flagged.

### EPIC-6 — token visibility (safe scam handling)
- `partitionSpamTokens` → `{visible, hidden}`: confirmed phishing (URL/keyword/suspicious-symbol/fake-stablecoin/dust) **hard-dropped**; user-`hidden` tokens → a **recoverable Hidden bucket** kept OUT of `cachedBalances` (totals never include hidden value).
- **No value-floor auto-suppression.** A high USD value is not evidence of fabrication and there's no trust signal to tell a scam from a legit unlisted token — so the "Mortal" class is handled by a **one-click per-token Hide** + the **recoverable Hidden section** (with un-hide). Nothing legit ever auto-vanishes or gets dropped from the total.
- **Durable visibility** — `SET_TOKEN_VISIBILITY` applies the override to the in-memory set deterministically (re-partition + persist, no network), so hide/un-hide survives a failed refetch or worker restart.
- **Price-aware tiers** — fake-stablecoin / `<$1` checks skip when `priceUsd` is 0. 21 spamFilter tests pass.

### Verification
- `tsc` green (side-panel + chrome-extension); 21 spamFilter tests pass.
- **Please verify on device** (fund-display branch): multi-account EVM total == AssetDetail; reopen panel → last-good balances (no $0 flash); a token Hide → lands in "Hidden", un-hide → returns and survives reload; testnet ETH shows no fake USD; legit unlisted tokens stay visible + counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
