### PR TITLE
feat(connection): harden vault pairing/init for always-on connectivity

### DIFF
--- a/HANDOFF_vault_connectivity_api.md
+++ b/HANDOFF_vault_connectivity_api.md
@@ -1,0 +1,144 @@
+# HANDOFF → vault: REST contract changes for "always-on" connectivity
+
+**From:** keepkey-client (BEX) — branch `feat/connection-hardening`
+**To:** keepkey-vault (v11, `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault`)
+**Companion to:** `HANDOFF_vault_pairing_persistence.md` (the internal storage/eviction
+fixes). This doc specifies the **exact REST contract** the BEX wants so the
+extension can stay connected without re-prompting.
+
+> Absolute paths throughout (multi-repo stack). Endpoints are on the local vault
+> REST server, base `http://localhost:1646`. Handlers live in
+> `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault/src/bun/rest-api.ts`
+> and `…/src/bun/auth.ts`.
+
+---
+
+## What the BEX now does (so you know what the contract has to support)
+
+As of this PR the BEX no longer blindly calls the SDK's auto-pair. On every init it:
+
+1. `GET /api/health` (no auth), up to 3 retries → if it never 200s, the BEX stays
+   **view-only from cache** and retries on its 5 s poll. **No pairing.**
+2. If it has a saved key: `GET /auth/pair` with `Authorization: Bearer <key>`, up to
+   3 retries.
+   - `200 { paired: true }` → **valid**, reuse the key, never prompt.
+   - `401` / `403` / `200 { paired: false }` → **invalid**, drop the key and pair once.
+   - network error / 5xx on all retries → **inconclusive** → treat as unreachable
+     (view-only + retry), **never** prompt.
+3. Only when it has no key, or the key was explicitly rejected, does it `POST
+   /auth/pair`. All init is single-flighted, so the BEX issues **at most one**
+   `POST /auth/pair` at a time.
+
+So the BEX already depends on two contract guarantees you must keep stable:
+**(A)** `GET /auth/pair` is a cheap, side-effect-free validity check, and **(B)** a
+`401`/`403`/`{paired:false}` means "this key is dead," not "transient." Both hold in
+the current handler (`rest-api.ts` L1429–1444) — please don't regress them.
+
+---
+
+## Request 1 — Idempotent `POST /auth/pair` (return existing key, no prompt)
+
+**Today:** every approved `POST /auth/pair` mints a new UUID + new paired-app row
+(`auth.ts` `approvePairing` L81–92). Re-pairing the same app always prompts and always
+creates a duplicate.
+
+**Wanted:** if the request's identity already has a **live** pairing, return that
+key immediately with **no device prompt**.
+
+**Request body (extended):**
+```jsonc
+{
+  "name":     "KeepKey Browser Extension",
+  "url":      "",
+  "imageUrl": "https://pioneers.dev/coins/keepkey.png",
+  "clientId": "bex-3f9c…"   // NEW, optional — stable per-install id (see Request 3)
+}
+```
+
+**Response — identity already paired (no prompt):**
+```jsonc
+HTTP 200
+{ "apiKey": "<existing-key>", "reused": true }
+```
+
+**Response — new identity (prompt as today):**
+```jsonc
+HTTP 200
+{ "apiKey": "<new-key>", "reused": false }   // after device approval
+```
+
+Identity match precedence: `clientId` if present, else `(name, url, imageUrl)`.
+"Live" = present in the key store and not expired. This single change removes the
+bulk of the re-approval pain.
+
+---
+
+## Request 2 — Coalesce concurrent pair requests (kill the 429 dead-end)
+
+**Today:** a second in-flight `POST /auth/pair` throws `429 "A pairing request is
+already pending"` (`auth.ts` `requestPair` L63–64). The SDK surfaces this as a fatal
+`SdkError` — historically the BEX's most common pairing failure.
+
+The BEX's single-flight makes self-collision rare, but a stale pending request from a
+previous service-worker generation (MV3 recycles the worker aggressively) can still
+collide. Desired behavior, in order of preference:
+
+- **Preferred — coalesce same identity:** if a pending request exists for the **same
+  identity**, attach the new caller to the **same** pending promise and resolve both
+  with the same key on approval. No 429.
+- **Acceptable — make 429 pollable:** keep the 429 but make it explicitly retryable:
+  ```jsonc
+  HTTP 409            // not 429 — 429 reads as rate-limit
+  Retry-After: 2
+  { "error": "pairing_pending", "pending": true }
+  ```
+  The BEX will then poll `GET /auth/pair` until `{paired:true}` (the other request's
+  approval lands) instead of erroring out.
+
+Either removes the "press refresh to escape a wedged pairing" loop.
+
+---
+
+## Request 3 — Accept a stable `clientId` for identity
+
+`name`/`url`/`imageUrl` are weak identity (any app can claim them, and the BEX sends
+`url: ""`). A stable per-install `clientId` lets the vault dedup reliably and lets you
+build a trustworthy paired-apps list.
+
+- The BEX will generate a UUID once, persist it in `chrome.storage.local`, and send it
+  as `clientId` on every `POST /auth/pair`.
+- Vault keys idempotency (Request 1) and the `paired_apps` row on `clientId` when
+  present. Suggest adding a nullable `client_id TEXT` column to `paired_apps`
+  (`src/bun/db.ts` L113–120) — backward compatible; legacy rows just have `NULL`.
+
+> The BEX side of this is a ~5-line change we'll ship once the vault accepts the field;
+> it's listed here so the contract is agreed first. Until then, dedup on
+> `(name, url, imageUrl)`.
+
+---
+
+## Request 4 (optional) — explicit unpair + duplicate cleanup
+
+For a clean "disconnect and re-pair" and to drain the existing duplicates:
+
+- `DELETE /auth/pair` with `Authorization: Bearer <key>` → revokes the caller's own
+  key (`auth.revoke`, already exists internally at `auth.ts` L110–114; just needs a
+  route). Lets the BEX's "Reset" flow revoke server-side instead of orphaning the key.
+- A one-time dedup on vault load (collapse same-identity rows, keep newest) so the 5
+  current "KeepKey Browser Extension" rows become 1. (Covered in the persistence
+  handoff; mirrored here because it's observable via `GET /auth/paired-apps`.)
+
+---
+
+## Contract summary (what the BEX will call)
+
+| Endpoint | Auth | BEX use | Required guarantee |
+|---|---|---|---|
+| `GET /api/health` | none | liveness, retried | 200 when up; cheap |
+| `GET /auth/pair` | Bearer | **validate saved key** before any pairing | `200 {paired:true}` valid · `401/403/{paired:false}` dead · side-effect-free |
+| `POST /auth/pair` | none (+ identity body) | pair **only** when no/dead key | **idempotent** (Req 1) · **coalesced** (Req 2) · `{apiKey, reused}` |
+| `DELETE /auth/pair` *(new, optional)* | Bearer | clean reset | revoke caller's key |
+
+Land **Request 1** and **Request 2** and the user-visible re-approval / "press
+refresh" churn is gone end-to-end (BEX hardening from this PR + these two contract
+changes). Requests 3–4 are durability/cleanup follow-ups.

--- a/HANDOFF_vault_pairing_persistence.md
+++ b/HANDOFF_vault_pairing_persistence.md
@@ -1,0 +1,180 @@
+# HANDOFF → vault: pairing dedup, eviction, TTL & timeout (the "re-approve every time" bug)
+
+**From:** keepkey-client (BEX) — branch `feat/connection-hardening`
+**To:** keepkey-vault (v11, `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault`)
+**Status of the client side:** the BEX-side connection hardening is done in this PR
+(single-flight init, retry-aware key validation, no reflexive key wipe). It removes
+the *client's* contribution to re-pairing. **The remaining re-approval churn is
+vault-side and cannot be fixed from the client.** This doc proves it and prescribes
+the fixes.
+
+> All file paths are absolute because this stack spans repos. The running vault at
+> the time of writing is the dev build of
+> `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault`
+> (PID confirmed listening on `:1646`).
+
+---
+
+## TL;DR — four defects, in priority order
+
+| # | Defect | File | Effect on user |
+|---|--------|------|----------------|
+| 1 | **Pairing is never deduplicated.** Every `POST /auth/pair` mints a brand-new UUID + new DB row for the *same* app identity. | `src/bun/auth.ts` `approvePairing()` L81–92, `pair()` L101–108; `src/bun/db.ts` `storePairing()` L898–908 | The paired-apps list grows without bound; a re-pair is always a *new* key, never a reuse. **Live proof:** `GET /auth/paired-apps` currently returns **5 identical "KeepKey Browser Extension" entries.** |
+| 2 | **Eviction is FIFO, not LRU, and `validate()` never refreshes recency.** | `src/bun/auth.ts` `MAX_KEYS=20` L30, `evictIfFull()` L160–168, `validate()` L121–141 | Once 20 pairings accumulate, each new pair evicts the **oldest by insertion order** — which can be the key the BEX is actively using → forced re-pair. |
+| 3 | **API-key TTL is measured from creation (`addedOn`) with no refresh-on-use; keys without `addedOn` are treated as expired.** `KEY_TTL_MS = 30 days`. | `src/bun/auth.ts` L32, L131–139 | An actively-used pairing hard-expires 30 days after it was *created*, regardless of use → periodic forced re-pair for daily users. |
+| 4 | **Pending-pair timeout mismatch.** Vault auto-rejects the pending request after **60 s**; the SDK's `POST /auth/pair` waits **600 s**. | vault `src/bun/auth.ts` L68–73; SDK `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-sdk/src/client.ts` `SIGNING_TIMEOUT_MS=600_000` L4, used at L135 | If the user takes >60 s to approve, the vault rejects while the client is still waiting → the approval the user *did* perform is discarded and they're prompted again. |
+
+Persistence itself is **not** broken: `paired_apps` is on-disk SQLite
+(`src/bun/db.ts` L113–120, `vault.db` under `Utils.paths.userData`), it is **not**
+dropped on `SCHEMA_VERSION` bumps (only `balances` / `pioneer_cache` are, L43–49),
+and `AuthStore.reloadPairings()` reloads it at construction (L40–60). So the keys
+survive a vault restart — the problem is purely **accumulation + eviction + TTL +
+timeout**, not loss.
+
+---
+
+## Defect 1 — idempotent pairing (highest impact)
+
+### Proof
+`src/bun/auth.ts`:
+```ts
+approvePairing(): string | null {
+  if (!this.pendingPair) return null
+  this.evictIfFull()
+  const apiKey = crypto.randomUUID()          // ← always a fresh key
+  const { info, resolve } = this.pendingPair
+  const enriched = { ...info, addedOn: Date.now() }
+  this.keys.set(apiKey, { apiKey, info: enriched })
+  storePairing(apiKey, { ... })               // ← always a new row
+  ...
+}
+```
+There is **no lookup by app identity** (`name` / `url` / `imageUrl`) anywhere before
+minting. `src/bun/db.ts` `storePairing()` does `INSERT OR REPLACE … paired_apps`
+keyed on `api_key` (the random UUID), so the upsert never collapses duplicates.
+
+```
+$ curl -s localhost:1646/auth/paired-apps | jq '.apps | length, (group_by(.name) | map({(.[0].name): length}))'
+5
+[ { "KeepKey Browser Extension": 5 } ]
+```
+
+### Fix
+Make pairing **idempotent on a stable app identity**. When an approval comes in for
+an identity that already has a live (non-expired) key, **reuse** that key instead of
+minting a new one:
+
+```ts
+approvePairing(): string | null {
+  if (!this.pendingPair) return null
+  const { info, resolve } = this.pendingPair
+  // Reuse an existing live pairing for the same identity (idempotent pairing).
+  const existing = this.findLiveByIdentity(info)
+  if (existing) {
+    existing.info.addedOn = Date.now()          // refresh recency (see defect 3)
+    storePairing(existing.apiKey, existing.info)
+    this.pendingPair = null
+    resolve(existing.apiKey)
+    return existing.apiKey
+  }
+  // …otherwise mint as today…
+}
+```
+Identity should be a stable tuple. `name` alone is weak (any app can claim
+"KeepKey Browser Extension"). **Preferred:** have the client send a stable
+`clientId` (see the companion API handoff `HANDOFF_vault_connectivity_api.md`) and
+key identity on that. **Minimum:** `(name, url, imageUrl)`.
+
+> Security note: idempotent reuse means "an app that was already approved doesn't
+> re-prompt." That is the desired behavior and matches how every other wallet
+> connector works. It does **not** weaken the initial approval gate — a *new*
+> identity still requires device approval.
+
+Also add a **dedup/migration sweep** on load so the existing 5+ duplicate rows
+collapse to one per identity (keep the most-recent `addedOn`).
+
+---
+
+## Defect 2 — LRU eviction (not FIFO)
+
+### Proof
+`src/bun/auth.ts`:
+```ts
+private evictIfFull() {
+  if (this.keys.size < MAX_KEYS) return
+  // Map iterates in insertion order — first key is oldest
+  const oldest = this.keys.keys().next().value   // ← FIFO, ignores last-use
+  if (oldest) { this.keys.delete(oldest); removePairing(oldest) }
+}
+```
+`validate()` (L121–141) returns the entry **without touching recency**, so "oldest
+inserted" never reflects "least recently used."
+
+### Fix
+Track `lastUsedOn`, bump it in `validate()` on every successful auth, and evict the
+entry with the smallest `lastUsedOn`. With defect 1 fixed the map won't fill from
+duplicates, but LRU is still correct insurance against evicting a hot key.
+
+---
+
+## Defect 3 — TTL should refresh on use
+
+### Proof
+`src/bun/auth.ts` `validate()`:
+```ts
+const addedOn = found.info.addedOn
+if (!addedOn || Date.now() - addedOn > KEY_TTL_MS) {   // 30 days from CREATION
+  this.keys.delete(apiKey); removePairing(apiKey); return null
+}
+```
+No write-back of a "last seen" timestamp → a key used every day still dies 30 days
+after it was first created.
+
+### Fix
+On successful `validate()`, set `lastUsedOn = Date.now()` and measure the TTL window
+against `lastUsedOn` (sliding expiry), persisting the bump. A key in active daily use
+then effectively never expires; an abandoned key still ages out in 30 days. (Throttle
+the persist to e.g. once/hour/key to avoid a DB write per request.)
+
+---
+
+## Defect 4 — align the pending-pair timeout
+
+### Proof
+vault `src/bun/auth.ts` `requestPair()`:
+```ts
+if (this.pendingPair) throw new HttpError(429, 'A pairing request is already pending')
+return new Promise((resolve, reject) => {
+  this.pendingPair = { info, resolve, reject }
+  setTimeout(() => {                       // ← 60 s
+    if (this.pendingPair?.info === info) { this.pendingPair = null; reject(new Error('Pairing request timed out')) }
+  }, 60000)
+})
+```
+SDK `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-sdk/src/client.ts`:
+`SIGNING_TIMEOUT_MS = 600_000` (L4), and `pair()` issues the POST with
+`signal: this.signal(this.signingTimeoutMs)` (L135). The published SDK the BEX ships
+(`…/keepkey-client/node_modules/keepkey-vault-sdk/lib/client.js`) is identical: 600 s.
+
+### Fix
+Raise the vault's pending-pair auto-reject to **match the SDK's 600 s** (or make it
+configurable and ≥ the SDK timeout). A user who walks over to the device and approves
+at 90 s should succeed, not be silently rejected and re-prompted.
+
+---
+
+## Suggested order of work
+1. **Defect 1** (idempotent pairing + collapse existing duplicates) — eliminates the
+   bulk of "approve a new key every time."
+2. **Defect 4** (timeout alignment) — quick, removes the slow-approval failure.
+3. **Defects 2 + 3** (LRU + sliding TTL) — durability for long-lived installs.
+
+## How to verify the fix
+- Pair the BEX once, approve. `GET /auth/paired-apps` → exactly **one** entry.
+- Restart the vault. BEX reconnects with **no** prompt (key still valid).
+- Re-trigger pairing from the BEX (e.g. reload the extension) → **no new entry**,
+  **no prompt** (idempotent reuse), same key returned.
+- Approve a fresh pairing after 90 s → succeeds (timeout aligned).
+
+See the companion **`HANDOFF_vault_connectivity_api.md`** for the exact REST contract
+changes (idempotent pair response, concurrent-pair coalescing, the `clientId` field).

--- a/chrome-extension/src/background/wallet.ts
+++ b/chrome-extension/src/background/wallet.ts
@@ -26,6 +26,118 @@ const state: WalletState = {
   deviceConnected: false,
 };
 
+const VAULT_BASE_URL = 'http://localhost:1646';
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Result of checking whether we can talk to the vault and whether our saved
+ * API key is still good — decided WITHOUT letting the SDK auto-pair.
+ *   - 'valid':       key works; hand it to the SDK so create() skips pairing.
+ *   - 'invalid':     vault is up and explicitly rejected the key (paired:false
+ *                    / 401 / 403), OR we have no key. The only case where a
+ *                    fresh pairing prompt is warranted.
+ *   - 'unreachable': vault down / transient blip / inconclusive. NEVER pair,
+ *                    NEVER wipe the key — run view-only and let the health poll
+ *                    re-init when the vault returns.
+ */
+type VaultAuthStatus = 'valid' | 'invalid' | 'unreachable';
+
+/**
+ * Gate the SDK's auto-pair behind our own retry-aware reachability + key check.
+ *
+ * Why this exists: KeepKeySdk.create() validates a supplied key with a single
+ * GET that returns false on ANY error (timeout, vault-busy at service-worker
+ * cold start) and then immediately pairs — surfacing a device approval prompt
+ * for what was only a transient blip. Repeated across the worker's frequent
+ * restarts, that's the "I have to approve a new key every time" churn. Here we
+ * retry, and crucially distinguish an explicit rejection (re-pair warranted)
+ * from a transient failure (retry later, key is probably fine).
+ */
+async function probeVaultAuth(apiKey?: string): Promise<VaultAuthStatus> {
+  const tag = TAG + ' | probeVaultAuth | ';
+  const RETRIES = 3;
+
+  let reachable = false;
+  for (let i = 0; i < RETRIES; i++) {
+    try {
+      const resp = await fetch(`${VAULT_BASE_URL}/api/health`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(4000),
+      });
+      if (resp.ok) {
+        reachable = true;
+        break;
+      }
+    } catch {
+      /* retry */
+    }
+    await delay(400 * (i + 1));
+  }
+  if (!reachable) {
+    console.warn(tag, 'Vault not reachable after retries — staying view-only');
+    return 'unreachable';
+  }
+
+  // Reachable but no saved key → must pair.
+  if (!apiKey) return 'invalid';
+
+  // Validate the saved key. An explicit reject means re-pair; a transient error
+  // means retry later — it must NOT escalate to a pairing prompt.
+  for (let i = 0; i < RETRIES; i++) {
+    try {
+      const resp = await fetch(`${VAULT_BASE_URL}/auth/pair`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (resp.ok) {
+        const data = await resp.json().catch(() => ({}) as any);
+        return data?.paired === true ? 'valid' : 'invalid';
+      }
+      if (resp.status === 401 || resp.status === 403) return 'invalid';
+      // 5xx / other: transient — retry
+    } catch {
+      /* network blip — retry */
+    }
+    await delay(400 * (i + 1));
+  }
+
+  // Health was OK but we never got a definitive auth verdict. Treat as
+  // unreachable (view-only + retry) rather than forcing a pairing prompt.
+  console.warn(tag, 'Key validation inconclusive — staying view-only, will retry');
+  return 'unreachable';
+}
+
+/**
+ * Populate state from the pubkey cache when the vault is unreachable, so the
+ * dashboard keeps showing last-good data instead of an error while the 5s
+ * health poll waits for the vault to return. No SDK is created — signing stays
+ * unavailable until a later init succeeds against a reachable vault.
+ */
+async function hydrateViewOnly(): Promise<void> {
+  state.deviceConnected = false;
+  if (state.paths.length === 0) state.paths = getDefaultPaths();
+  try {
+    const cached = await pubkeyStorage.loadPubkeys();
+    if (cached?.pubkeys?.length) {
+      state.pubkeys = cached.pubkeys;
+      if (cached.deviceInfo) {
+        const di = cached.deviceInfo;
+        state.deviceInfo = {
+          label: di.label,
+          model: di.model ?? 'KeepKey',
+          deviceId: di.deviceId ?? 'unknown',
+          features: di.features,
+        };
+      }
+    }
+  } catch {
+    /* ignore — nothing cached yet */
+  }
+  state.initialized = state.pubkeys.length > 0;
+}
+
 /**
  * Probe the device via getFeatures(). Updates state.deviceConnected and state.deviceInfo.
  * Returns true if the device is reachable, false otherwise.
@@ -57,7 +169,24 @@ export async function probeDevice(): Promise<boolean> {
  * View-only mode: if the device is not connected but cached pubkeys exist, init still
  * succeeds. Signing will fail later until the device is reconnected.
  */
-export async function init(): Promise<WalletState> {
+let initInFlight: Promise<WalletState> | null = null;
+
+export function init(): Promise<WalletState> {
+  // Single-flight: collapse concurrent/rapid init calls into ONE SDK creation.
+  // The boot timer, the 5s health-poll retry, and ON_START from the side panel
+  // (Connect + refresh) all call onStart()→init() and can overlap. Without this
+  // guard each caller POSTs /auth/pair and the second collides with the first's
+  // still-pending request → "A pairing request is already pending", which
+  // surfaced as an errored icon the user fixed by mashing refresh — spawning yet
+  // more pair attempts. One in-flight init serializes them.
+  if (initInFlight) return initInFlight;
+  initInFlight = doInit().finally(() => {
+    initInFlight = null;
+  });
+  return initInFlight;
+}
+
+async function doInit(): Promise<WalletState> {
   const tag = TAG + ' | init | ';
   try {
     console.log(tag, 'Initializing wallet...');
@@ -66,10 +195,38 @@ export async function init(): Promise<WalletState> {
     const savedApiKey = (await keepKeyApiKeyStorage.getApiKey()) || undefined;
     console.log(tag, 'Saved API key:', savedApiKey ? 'found' : 'none');
 
-    // Create SDK instance (pairs with vault on localhost:1646; no device needed)
+    // Decide reachability + key validity ourselves, with retries, BEFORE the SDK
+    // can auto-pair. This is what keeps a transient vault blip from turning into
+    // a device approval prompt.
+    const authStatus = await probeVaultAuth(savedApiKey);
+    if (authStatus === 'unreachable') {
+      if (state.sdk && state.initialized) {
+        console.warn(tag, 'Vault blip during re-init — keeping existing live state');
+        return state;
+      }
+      console.warn(tag, 'Vault unreachable — running view-only from cache, will retry on next poll');
+      await hydrateViewOnly();
+      return state;
+    }
+
+    // Only drop the saved key when the vault is up AND explicitly rejected it —
+    // the sole case where a fresh pairing is genuinely required.
+    let keyForSdk = savedApiKey;
+    if (authStatus === 'invalid' && savedApiKey) {
+      console.warn(tag, 'Vault rejected saved key — clearing it so we pair once');
+      keyForSdk = undefined;
+      try {
+        await keepKeyApiKeyStorage.saveApiKey('');
+      } catch {
+        /* ignore */
+      }
+    }
+
+    // Create SDK instance (pairs with vault on localhost:1646 only when keyForSdk
+    // is undefined — i.e. no key or a vault-rejected key; no device needed).
     const sdk = await KeepKeySdk.create({
-      apiKey: savedApiKey,
-      baseUrl: 'http://localhost:1646',
+      apiKey: keyForSdk,
+      baseUrl: VAULT_BASE_URL,
       serviceName: 'KeepKey Browser Extension',
       serviceImageUrl: 'https://pioneers.dev/coins/keepkey.png',
     });
@@ -268,13 +425,21 @@ async function fetchPubkeys(): Promise<void> {
  * stale pubkeys) is the bug we're fixing.
  */
 function isAuthError(e: unknown): boolean {
+  // Prefer the structured status (SdkError carries one) — it's unambiguous.
+  const status = (e as any)?.status;
+  if (status === 401 || status === 403) return true;
+  // Fall back to message matching, but NOT on a bare 'auth' substring: that
+  // matched "authenticating", "authorization pending", proxy/middleware noise,
+  // etc., and a false positive here WIPES the saved key and forces a re-pair.
   const msg = ((e as Error)?.message || String(e)).toLowerCase();
   return (
     msg.includes('401') ||
+    msg.includes('403') ||
     msg.includes('unauthorized') ||
-    msg.includes('auth') ||
     msg.includes('invalid api key') ||
-    msg.includes('not paired')
+    msg.includes('invalid or expired api key') ||
+    msg.includes('not paired') ||
+    msg.includes('re-pair')
   );
 }
 


### PR DESCRIPTION
## Problem

The background service worker re-paired with the vault far too often — spamming `SdkError: Pairing failed: {"error":"A pairing request is already pending"}` and forcing the user to **re-approve a new key on the device** repeatedly, plus "press refresh" to recover from an errored icon.

## Root causes (proven, client-side — fixed here)

1. **No single-flight on `wallet.init()`.** The boot timer, the 5s health-poll retry (`index.ts:234`), and `ON_START` (Connect + refresh buttons) all call `onStart()`→`init()` and can overlap. Each POSTed `/auth/pair`; the second collided with the first's still-pending request → `429 "already pending"` → errored icon → user mashes refresh → *more* pair attempts.
2. **SDK `verifyAuth()` has no retry** and pairs on **any** failure, so a transient vault blip at service-worker cold start escalated straight to a device approval prompt.
3. **`isAuthError()` matched the bare substring `'auth'`**, and a false positive **wiped the saved key** (`saveApiKey('')`) — a self-inflicted re-pair on the next init.

All three were independently confirmed against source by an adversarial review pass.

## Changes — `chrome-extension/src/background/wallet.ts` only

- **Single-flight `init()`** — concurrent callers share one in-flight promise; at most one `POST /auth/pair` is ever outstanding.
- **`probeVaultAuth()`** — retry-aware health + key check **before** the SDK can auto-pair. Distinguishes `valid` / explicitly-`invalid` / `unreachable`, and only pairs when the key is genuinely absent or vault-rejected. Transient/unreachable → view-only from cache + retry on the next poll, **never** a prompt, **never** a key wipe.
- **`hydrateViewOnly()`** — keep showing last-good cached balances when the vault is briefly down instead of an errored icon; auto-recovers on the 5s poll.
- **`isAuthError()`** — keys off the structured HTTP status (401/403) and drops the over-broad `'auth'` substring, so transient errors no longer destroy the key.

## Vault-side (proven, **not** client-fixable — handed off)

The running vault has **5 duplicate "KeepKey Browser Extension" pairings** (`GET /auth/paired-apps`). Documented for the vault team:

- **`HANDOFF_vault_pairing_persistence.md`** — no dedup (every pair mints a new UUID), FIFO eviction at `MAX_KEYS=20`, 30-day TTL from creation with no refresh-on-use, and a 60s pending-timeout vs the SDK's 600s wait.
- **`HANDOFF_vault_connectivity_api.md`** — exact REST contract asks: idempotent `POST /auth/pair` (return existing key, no prompt), concurrent-pair coalescing instead of `429`, a stable `clientId` for identity.

Vault **persistence is sound** (survives restart + schema bump) — the churn is dedup/eviction/TTL/timeout, not key loss.

## Verification
- `make type-check` → 15/15 ✓
- `make build` (Chrome) → 9/9 ✓
- eslint on the changed file → 0 errors (pre-existing `no-explicit-any` warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)