### PR TITLE
feat(side-panel): asset-detail hero — auto-loading tokens + 8-decimal dust balances

### DIFF
--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -28,6 +28,7 @@ import { requestStorage } from '@extension/storage';
 import Connect from './components/Connect';
 import Loading from './components/Loading';
 import Balances from './components/Balances';
+import { SpinningDevice } from './components/SpinningDevice';
 import History from './components/History';
 import Settings from './components/Settings';
 import { Transfer } from './components/Transfer';
@@ -322,8 +323,8 @@ const SidePanel = () => {
       default:
         return (
           <Flex direction="column" justifyContent="center" alignItems="center" height="100%" minH="300px">
-            <Box mb={4} borderRadius="2xl" overflow="hidden" boxShadow="0 0 40px rgba(0, 200, 150, 0.15)">
-              <img src="/kk.gif" alt="KeepKey" style={{ maxWidth: '160px', borderRadius: '16px' }} />
+            <Box mb={4}>
+              <SpinningDevice scale={0.46} durationSeconds={10} label="KEEPKEY" />
             </Box>
             <Text fontSize="xl" fontWeight="bold" textAlign="center" mb={1} color="white">
               Welcome to KeepKey

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -18,6 +18,8 @@ import {
 } from '@chakra-ui/react';
 import { ArrowUpIcon, ArrowDownIcon, CopyIcon, CheckIcon, ExternalLinkIcon, RepeatIcon } from '@chakra-ui/icons';
 import { AssetIcon } from './AssetIcon';
+import { SpinningDevice } from './SpinningDevice';
+import { KNOWN_EVM_CHAINS, EVM_NATIVE_GAS } from './header/headerConstants';
 import { getExplorerAddressUrl, getExplorerTxUrl } from '@extension/shared';
 import { Tokens } from './Tokens';
 import { requestStorage } from '@extension/storage';
@@ -63,6 +65,26 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
 
   // Build icon URL
   const iconUrl = asset.icon || `https://api.keepkey.info/coins/${btoa(asset.caip || '').replace(/=+$/, '')}.png`;
+
+  // EVM native-asset labeling. The dashboard rows carry the chain's short symbol
+  // as the "asset" (Base→BASE, Arbitrum→ARB, Optimism→OP), but those chains pay
+  // gas in ETH — so the page should read "Ethereum / ETH on Base". Only relabel
+  // the *native* row (never an ERC-20): a token like USDC keeps its own name.
+  const chainMeta = isEvm ? KNOWN_EVM_CHAINS[asset.networkId as keyof typeof KNOWN_EVM_CHAINS] : undefined;
+  // Only the native row gets gas-asset relabeling. The symbol-match fallback
+  // (for native rows that arrive without isNative set) must exclude ERC-20s —
+  // otherwise the ARB/OP/MATIC *governance tokens*, whose tickers equal their
+  // chain's dropdown symbol, get mislabeled as "Ethereum / ETH on Arbitrum".
+  // Token rows reliably carry token:true through SET_ASSET_CONTEXT.
+  const isNativeRow = asset.isNative === true || (!asset.token && !!chainMeta && asset.symbol === chainMeta.symbol);
+  const gasAsset = isEvm && isNativeRow ? EVM_NATIVE_GAS[asset.networkId as keyof typeof EVM_NATIVE_GAS] : undefined;
+  const displaySymbol = gasAsset?.symbol ?? asset.symbol;
+  const displayName = gasAsset?.name ?? asset.name ?? asset.symbol;
+  const networkName = chainMeta?.name ?? asset.name;
+  // "on <network>" only when the gas asset differs from its host chain (ETH on
+  // Base) — not for a chain's own namesake token (ETH on Ethereum, AVAX on
+  // Avalanche).
+  const showNetworkBadge = !!gasAsset && !!networkName && gasAsset.name !== networkName;
 
   // Fetch address and live balance when asset changes
   useEffect(() => {
@@ -179,27 +201,41 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
 
   return (
     <Flex direction="column" h="100%" minH={0}>
-      {/* Top spacer — pushes hero/address/buttons up off the top edge.
-          Smaller than the tabs flex grow below (1 : 2) so the hero sits at
-          roughly the upper third rather than dead-center; visually the
-          balance + Send/Receive block reads as the focal point. */}
-      <Box flex={1} minH={0} flexShrink={1} />
-
-      {/* Balance Hero */}
-      <VStack spacing={1} align="center" pt={3} pb={2} px={2} flexShrink={0}>
-        <HStack spacing={2} align="center">
-          <AssetIcon src={iconUrl} symbol={asset.symbol} size={32} />
-          <Text fontSize="sm" fontWeight="medium" color="kk.dim">
-            {asset.name || asset.symbol}
-          </Text>
-          {asset.networkId === 'tron:27Lqcw' && <TronLinkBadge />}
-        </HStack>
-        <Text fontSize="xl" fontWeight="bold" color="kk.text" lineHeight="1.2">
+      {/* Spinning KeepKey hero — the device's OLED carries the asset + balance,
+          so the top of the page reads as the focal point instead of dead space.
+          Device sits at the top; the tab list below (flex grow) takes the rest,
+          so there's no empty band above or below. */}
+      <VStack spacing={1} align="center" pt={3} pb={1} px={2} flexShrink={0}>
+        <SpinningDevice
+          scale={0.42}
+          durationSeconds={14}
+          screen={
+            <Flex direction="column" align="center" justify="center" w="100%" gap="2px" lineHeight="1">
+              <Flex align="center" gap="5px">
+                <AssetIcon src={iconUrl} symbol={displaySymbol} size={15} />
+                <Text fontSize="11px" fontWeight={600} letterSpacing="0.08em" color="#e8e6dc">
+                  {displaySymbol}
+                </Text>
+              </Flex>
+              <Text fontFamily="ui-monospace, Menlo, monospace" fontSize="15px" fontWeight={700} color="#f3f1e7">
+                <DustAmount value={totalBalance} />
+              </Text>
+            </Flex>
+          }
+        />
+        <Text fontSize="2xl" fontWeight="bold" color="kk.text" lineHeight="1.1">
           {formatUsd(totalUsdValue)}
         </Text>
+        <HStack spacing={2} align="center">
+          <Text fontSize="sm" fontWeight="medium" color="kk.dim">
+            {displayName}
+          </Text>
+          {showNetworkBadge && <NetworkBadge name={networkName!} />}
+          {asset.networkId === 'tron:27Lqcw' && <TronLinkBadge />}
+        </HStack>
         <HStack spacing={1}>
-          <Text fontSize="xs" color="kk.dim">
-            {totalBalance.toFixed(4)} {asset.symbol}
+          <Text fontSize="xs" color="kk.faint">
+            <DustAmount value={totalBalance} /> {displaySymbol}
           </Text>
           {priceUsd > 0 && (
             <Text fontSize="xs" color="kk.faint">
@@ -292,9 +328,9 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
         )}
       </HStack>
 
-      {/* Tab Bar — Tokens / Activity. flex={2} vs the top spacer's flex={1}
-          biases the hero block higher (≈ upper third) instead of dead-center. */}
-      <Box flex={2} minH={0} px={2}>
+      {/* Tab Bar — Tokens / Activity. flex grows to fill everything below the
+          hero so the list reaches the bottom edge (no trailing empty band). */}
+      <Box flex={1} minH={0} px={2}>
         <Tabs variant="soft-rounded" size="sm" display="flex" flexDirection="column" h="100%">
           <TabList mb={1} gap={1} flexShrink={0}>
             {!isUtxoNetwork && (
@@ -423,6 +459,50 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
     </Flex>
   );
 };
+
+// Renders a crypto amount with up to 8 decimals of precision. The integer and
+// first 4 decimals read at full size; decimals 5–8 ("dust") render smaller and
+// dimmer, so a headline balance stays scannable while sub-0.0001 precision is
+// still legible at a glance. Trailing-zero dust is trimmed (0.5 → "0.5000", not
+// "0.50000000"). Meant to sit inside a <Text>: the spans inherit its font and
+// color; only the dust shrinks and fades.
+const DustAmount = ({ value }: { value: number }) => {
+  const [intPart, frac = ''] = (Number.isFinite(value) ? value : 0).toFixed(8).split('.');
+  const head = frac.slice(0, 4);
+  const dust = frac.slice(4).replace(/0+$/, '');
+  return (
+    <>
+      {intPart}.{head}
+      {dust && (
+        <Box as="span" fontSize="0.7em" opacity={0.5}>
+          {dust}
+        </Box>
+      )}
+    </>
+  );
+};
+
+// Network badge shown next to a native asset whose gas token differs from its
+// host chain (e.g. "Ethereum  ◦on Base"). The glyph is AssetIcon's deterministic
+// monogram keyed on the network name, so it reads as an intentional branded mark
+// rather than a generic dot.
+const NetworkBadge = ({ name }: { name: string }) => (
+  <Flex
+    align="center"
+    gap={1}
+    pl="3px"
+    pr={2}
+    py="2px"
+    borderRadius="full"
+    bg="kk.surface"
+    border="1px solid"
+    borderColor="kk.line">
+    <AssetIcon symbol={name} size={12} />
+    <Text fontSize="9px" color="kk.dim" fontWeight={600} letterSpacing="0.04em">
+      on {name}
+    </Text>
+  </Flex>
+);
 
 // Passive indicator shown next to the asset name on the Tron asset page —
 // tells the user Tron dApps use the TronLink protocol (which KeepKey

--- a/pages/side-panel/src/components/Connect.tsx
+++ b/pages/side-panel/src/components/Connect.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { Image, Button, Card, Stack, Text, Box, Spinner } from '@chakra-ui/react';
+import { Button, Card, Stack, Text, Box, Spinner } from '@chakra-ui/react';
+import { SpinningDevice } from './SpinningDevice';
 
 interface ConnectProps {
   setIsConnecting: (isConnecting: boolean) => void;
@@ -83,7 +84,11 @@ const Connect: React.FC<ConnectProps> = ({ setIsConnecting }) => {
         boxShadow="lg"
         borderWidth="1px"
         borderColor="kk.line">
-        <Image src={'https://i.ibb.co/jR8WcJM/kk.gif'} alt="KeepKey" />
+        {/* Spins slowly with a dim OLED — reads as a powered-but-unreachable
+            device while we poll localhost:1646 for the vault to come up. */}
+        <Box mb={2}>
+          <SpinningDevice scale={0.4} durationSeconds={16} label="OFFLINE" />
+        </Box>
         <Text fontSize="lg" fontWeight="bold" mb={2} color="kk.text">
           KeepKey Vault Required
         </Text>

--- a/pages/side-panel/src/components/Loading.tsx
+++ b/pages/side-panel/src/components/Loading.tsx
@@ -1,39 +1,113 @@
-import React, { useEffect } from 'react';
-import { Image, Button, Card, Stack, Text, Box, Spinner } from '@chakra-ui/react';
+import React, { useEffect, useState } from 'react';
+import { Box, Flex, Text } from '@chakra-ui/react';
+import { SpinningDevice } from './SpinningDevice';
 
-interface ConnectProps {
+interface LoadingProps {
   setIsConnecting: (isConnecting: boolean) => void;
   keepkeyState: any;
 }
 
-const Loading: React.FC<ConnectProps> = ({ setIsConnecting, keepkeyState }) => {
+// Cycling "…" rendered in its own component so the ticking state never
+// re-renders the (DOM-heavy) SpinningDevice. Fixed width keeps the label from
+// shifting as dots appear/disappear.
+const LoadingDots: React.FC = () => {
+  const [n, setN] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setN(d => (d + 1) % 4), 420);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <Box as="span" display="inline-block" w="1.4em" textAlign="left">
+      {'.'.repeat(n)}
+    </Box>
+  );
+};
+
+// Branded loading screen: the KeepKey spins (fast, "working" cadence) with an
+// animated LOADING… readout + indeterminate progress bar on its OLED, over a
+// pulsing accent glow. Everything eases in on mount (fade + rise) so the panel
+// doesn't pop. Replaces the old raw Chakra spinner + "Status: N" debug text.
+const Loading: React.FC<LoadingProps> = ({ setIsConnecting, keepkeyState }) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       setIsConnecting(false);
     }, 3000);
-
-    // Cleanup the timer on component unmount
     return () => clearTimeout(timer);
   }, [setIsConnecting]);
 
+  // State 3 is "busy" (device mid-operation); the rest are pre-pair connection
+  // phases. Tailor the subtext so the screen reads as informative, not generic.
+  const subtext = keepkeyState === 3 ? 'Waking your KeepKey…' : 'Connecting to KeepKey Vault…';
+
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" height="100vh">
-      <Card
-        borderRadius="md"
-        p={6}
-        mb={6}
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        textAlign="center"
-        boxShadow="lg">
-        <Box textAlign="center">
-          <h2>Status: {keepkeyState}</h2>
-          <Spinner size="6xl" />
-          <Text mt={4}>Connecting to KeepKey Vault...</Text>
-        </Box>
-      </Card>
-    </Box>
+    <Flex direction="column" align="center" justify="center" h="100vh" px={6} position="relative" overflow="hidden">
+      <style>{`
+        @keyframes kkLoadEnter { from { opacity:0; transform: translateY(10px) scale(.94); } to { opacity:1; transform:none; } }
+        @keyframes kkLoadRise  { from { opacity:0; transform: translateY(8px); } to { opacity:1; transform:none; } }
+        @keyframes kkLoadGlow  { 0%,100% { opacity:.30; transform: translate(-50%,-50%) scale(1); } 50% { opacity:.6; transform: translate(-50%,-50%) scale(1.14); } }
+        @keyframes kkLoadBar   { 0% { transform: translateX(-120%); } 100% { transform: translateX(320%); } }
+      `}</style>
+
+      {/* Pulsing accent glow behind the device */}
+      <Box
+        position="absolute"
+        top="42%"
+        left="50%"
+        w="240px"
+        h="240px"
+        borderRadius="full"
+        pointerEvents="none"
+        style={{
+          background: 'radial-gradient(circle, rgba(210,153,41,0.34) 0%, rgba(210,153,41,0) 68%)',
+          transform: 'translate(-50%,-50%)',
+          animation: 'kkLoadGlow 3.2s ease-in-out infinite',
+        }}
+      />
+
+      <Box style={{ animation: 'kkLoadEnter .6s cubic-bezier(.2,.7,.2,1) both' }}>
+        <SpinningDevice
+          scale={0.5}
+          durationSeconds={3.2}
+          screen={
+            <Flex direction="column" align="center" justify="center" w="100%" gap="4px">
+              <Text
+                as="span"
+                fontFamily="ui-monospace, Menlo, monospace"
+                fontSize="12px"
+                fontWeight={700}
+                letterSpacing="0.16em"
+                color="#e8e6dc"
+                whiteSpace="nowrap">
+                LOADING
+                <LoadingDots />
+              </Text>
+              {/* Indeterminate progress shuttle — implies activity without faking a percentage */}
+              <Box w="62px" h="3px" borderRadius="full" bg="rgba(232,230,220,0.14)" overflow="hidden">
+                <Box
+                  h="100%"
+                  w="45%"
+                  borderRadius="full"
+                  bg="#d29929"
+                  style={{ animation: 'kkLoadBar 1.5s ease-in-out infinite' }}
+                />
+              </Box>
+            </Flex>
+          }
+        />
+      </Box>
+
+      <Text
+        mt={5}
+        fontSize="md"
+        fontWeight="semibold"
+        color="kk.text"
+        style={{ animation: 'kkLoadRise .6s ease .15s both' }}>
+        Waking your KeepKey
+      </Text>
+      <Text mt={1} fontSize="xs" color="kk.dim" style={{ animation: 'kkLoadRise .6s ease .28s both' }}>
+        {subtext}
+      </Text>
+    </Flex>
   );
 };
 

--- a/pages/side-panel/src/components/Tokens.tsx
+++ b/pages/side-panel/src/components/Tokens.tsx
@@ -5,6 +5,13 @@ import { customTokensStorageApi, type CustomToken } from '@extension/storage';
 import { CustomTokenDialog } from './CustomTokenDialog';
 import { AssetIcon } from './AssetIcon';
 
+// Networks we've already auto-kicked a token discovery for this side-panel
+// session. Module-scoped (not per-component) on purpose: the asset Drawer
+// unmounts Tokens on close, so a useRef would reset and re-fire a heavy
+// /portfolio force-refresh on every reopen of a token-less chain. Persisting
+// here means we force discovery at most once per network per page session.
+const autoDiscoveredNetworks = new Set<string>();
+
 interface TokensProps {
   asset: any;
   networkId?: string;
@@ -85,9 +92,39 @@ export const Tokens = ({ asset, networkId }: TokensProps) => {
           });
 
           setTokens(networkTokens);
-          // Background signals it kicked token discovery for a natives-only
-          // cache — show the discovering state rather than a premature empty.
-          setDiscovering(Boolean(response.discovering) && networkTokens.length === 0);
+
+          // The background's `discovering` flag is global — any cached token on
+          // ANY chain (or an already-completed forced discovery) clears it. So a
+          // network the user opens for the first time can hold zero cached token
+          // rows yet report discovering=false, stranding them on "No Tokens
+          // Found" until they press Discover. Auto-kick ONE forced portfolio
+          // round-trip per network so tokens load on page open; the commit
+          // pushes BALANCES_UPDATED which repaints us, and the module-level set
+          // stops a re-trigger loop when the chain genuinely has none.
+          const bgDiscovering = Boolean(response.discovering) && networkTokens.length === 0;
+          if (
+            networkTokens.length === 0 &&
+            !bgDiscovering &&
+            effectiveNetworkId &&
+            !autoDiscoveredNetworks.has(effectiveNetworkId)
+          ) {
+            autoDiscoveredNetworks.add(effectiveNetworkId);
+            setDiscovering(true);
+            chrome.runtime.sendMessage({ type: 'REFRESH_ALL_BALANCES' }, (refreshResp: any) => {
+              // Resolve the spinner terminally. A committed discovery repaints us
+              // via the BALANCES_UPDATED listener (which clears `discovering` and
+              // shows whatever tokens landed). But the background's early-return
+              // and error paths — no pubkeys yet, wallet not initialized, Pioneer
+              // 5xx — reply WITHOUT broadcasting, so without this the user would
+              // hang on "Discovering…" forever. Drop back to the empty/error state
+              // unless tokens actually came back.
+              if (chrome.runtime.lastError || refreshResp?.error || !refreshResp?.balances?.length) {
+                setDiscovering(false);
+              }
+            });
+          } else {
+            setDiscovering(bgDiscovering);
+          }
         }
         setLoading(false);
       });

--- a/pages/side-panel/src/components/header/headerConstants.ts
+++ b/pages/side-panel/src/components/header/headerConstants.ts
@@ -11,6 +11,36 @@ export const KNOWN_EVM_CHAINS: Record<string, { name: string; symbol: string }> 
   'eip155:324': { name: 'zkSync Era', symbol: 'ZKSYNC' },
 };
 
+// The native *gas* asset per EVM chain — distinct from the chain's own short
+// symbol above (which labels the network in the header dropdown). Base,
+// Arbitrum, Optimism and zkSync all pay gas in ETH, so an asset page must read
+// "Ethereum / ETH on Base" — never "Base / BASE" (BASE/ARB/OP are chain labels
+// or governance tokens, not the gas token the balance is actually denominated
+// in). Chains whose gas token IS their namesake (ETH/AVAX/POL) get no "on X"
+// qualifier. Custom networks fall back to their own row symbol.
+export const EVM_NATIVE_GAS: Record<string, { name: string; symbol: string }> = {
+  'eip155:1': { name: 'Ethereum', symbol: 'ETH' },
+  'eip155:42161': { name: 'Ethereum', symbol: 'ETH' },
+  'eip155:43114': { name: 'Avalanche', symbol: 'AVAX' },
+  'eip155:56': { name: 'BNB', symbol: 'BNB' },
+  'eip155:8453': { name: 'Ethereum', symbol: 'ETH' },
+  'eip155:10': { name: 'Ethereum', symbol: 'ETH' },
+  'eip155:137': { name: 'Polygon', symbol: 'POL' },
+  'eip155:324': { name: 'Ethereum', symbol: 'ETH' },
+};
+
+// Resolve a short human network name from a networkId OR a caip (the
+// `/slip44:…` asset suffix is stripped). EVM → KNOWN_EVM_CHAINS, everything
+// else → NETWORK_DISPLAY_NAMES. Returns '' when unknown so callers can fall
+// back (e.g. to a title-cased chainId). Used to tell same-symbol assets on
+// different chains apart — "ETH on Base" vs "ETH on Ethereum".
+export function getNetworkName(networkIdOrCaip?: string): string {
+  if (!networkIdOrCaip) return '';
+  const networkId = networkIdOrCaip.split('/')[0];
+  if (networkId.startsWith('eip155:')) return KNOWN_EVM_CHAINS[networkId]?.name || '';
+  return NETWORK_DISPLAY_NAMES[networkId] || '';
+}
+
 export const NETWORK_DISPLAY_NAMES: Record<string, string> = {
   'bip122:000000000019d6689c085ae165831e93': 'Bitcoin',
   'bip122:000000000000000000651ef99cb9fcbe': 'Bitcoin Cash',

--- a/pages/side-panel/src/swap/AssetPicker.tsx
+++ b/pages/side-panel/src/swap/AssetPicker.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState, useRef, useEffect } from 'react';
 import type { SwapTheme } from './theme';
 import type { UiAsset } from './types';
 import { Icon, I } from './icons';
-import { TokenGlyph, fmtUsd, fmtCrypto } from './ui';
+import { TokenGlyph, fmtUsd, fmtCrypto, assetSubLabel } from './ui';
 
 export interface HeldBalance {
   amount: number;
@@ -171,7 +171,7 @@ export function AssetPicker({
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                   }}>
-                  {a.name}
+                  {assetSubLabel(a)}
                 </div>
               </div>
               {bal ? (

--- a/pages/side-panel/src/swap/SwapProgress.tsx
+++ b/pages/side-panel/src/swap/SwapProgress.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import type { SwapTheme } from './theme';
 import type { UiAsset, SwapHistoryRecord, SwapTrackingStatus } from './types';
 import { Icon, I } from './icons';
-import { PrimaryBtn, TokenGlyph, SwapEmblem, SwapTimeline } from './ui';
+import { PrimaryBtn, TokenGlyph, SwapEmblem, SwapTimeline, networkLabelFor } from './ui';
 
 const PROG: Record<SwapTrackingStatus, number> = {
   signing: 0.04,
@@ -248,6 +248,7 @@ export function SwapProgress({
             <div className="mono" style={{ fontSize: 13, fontWeight: 600 }}>
               {fromAmount} {from.symbol}
             </div>
+            <div style={{ fontSize: 10, color: T.faint }}>{networkLabelFor(from)}</div>
           </div>
         </div>
         <Icon d={I.chev} size={16} style={{ color: T.accent, flexShrink: 0 }} />
@@ -259,6 +260,7 @@ export function SwapProgress({
                 : `~${outNum < 1 ? outNum.toFixed(8) : outNum.toFixed(4)}`}{' '}
               {to.symbol}
             </div>
+            <div style={{ fontSize: 10, color: T.faint }}>{networkLabelFor(to)}</div>
           </div>
           <TokenGlyph asset={to} size={36} />
         </div>

--- a/pages/side-panel/src/swap/SwapReview.tsx
+++ b/pages/side-panel/src/swap/SwapReview.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import type { SwapTheme } from './theme';
 import type { UiAsset, SwapQuote } from './types';
 import { Icon, I } from './icons';
-import { IconBtn, PrimaryBtn, TokenGlyph, fmtCrypto } from './ui';
+import { IconBtn, PrimaryBtn, TokenGlyph, fmtCrypto, networkLabelFor } from './ui';
 
 export function SwapReview({
   T,
@@ -94,6 +94,7 @@ export function SwapReview({
                 {amount} {from.symbol}
               </span>
             </div>
+            <div style={{ fontSize: 10, color: T.faint, marginTop: 2 }}>{networkLabelFor(from)}</div>
           </div>
           <Icon d={I.chev} size={16} style={{ color: T.faint, flexShrink: 0 }} />
           <div style={{ textAlign: 'right', minWidth: 0 }}>
@@ -104,6 +105,7 @@ export function SwapReview({
               </span>
               <TokenGlyph asset={to} size={22} />
             </div>
+            <div style={{ fontSize: 10, color: T.faint, marginTop: 2 }}>{networkLabelFor(to)}</div>
           </div>
         </div>
       </div>

--- a/pages/side-panel/src/swap/ui.tsx
+++ b/pages/side-panel/src/swap/ui.tsx
@@ -5,6 +5,25 @@ import React, { useState, useEffect } from 'react';
 import type { SwapTheme } from './theme';
 import { Icon, I } from './icons';
 import type { UiAsset } from './types';
+import { getNetworkName } from '../components/header/headerConstants';
+
+const capitalize = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
+
+/** Short network label for a swap asset — "Base", "Ethereum", "Bitcoin". The
+ *  swap UI shows only a symbol, so ETH-on-Base and ETH-on-Ethereum look
+ *  identical; this is what tells them apart. Derives from the caip, falling
+ *  back to the asset's internal chainId. */
+export function networkLabelFor(asset: { caip?: string; chainId?: string }): string {
+  return getNetworkName(asset.caip) || capitalize(asset.chainId);
+}
+
+/** "{name} · {network}" for list rows, collapsing to one when they'd repeat
+ *  (e.g. native ETH whose name and network are both "Ethereum"). */
+export function assetSubLabel(asset: { name?: string; caip?: string; chainId?: string }): string {
+  const net = networkLabelFor(asset);
+  if (asset.name && net && asset.name !== net) return `${asset.name} · ${net}`;
+  return net || asset.name || '';
+}
 
 export const fmtUsd = (n: number, show = true) =>
   show ? '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '••••••';
@@ -139,6 +158,7 @@ export function PrimaryBtn({
 }
 
 export function TokenButton({ T, asset, onClick }: { T: SwapTheme; asset: UiAsset; onClick?: () => void }) {
+  const network = networkLabelFor(asset);
   return (
     <button
       onClick={onClick}
@@ -146,7 +166,7 @@ export function TokenButton({ T, asset, onClick }: { T: SwapTheme; asset: UiAsse
         display: 'flex',
         alignItems: 'center',
         gap: 8,
-        padding: '6px 10px 6px 6px',
+        padding: '5px 10px 5px 6px',
         borderRadius: 999,
         border: `1px solid ${T.line}`,
         background: T.surfaceHi,
@@ -154,7 +174,11 @@ export function TokenButton({ T, asset, onClick }: { T: SwapTheme; asset: UiAsse
         cursor: 'pointer',
       }}>
       <TokenGlyph asset={asset} size={26} />
-      <span style={{ fontWeight: 600, fontSize: 14 }}>{asset.symbol}</span>
+      {/* Symbol over the network name so ETH-on-Base ≠ ETH-on-Ethereum at a glance */}
+      <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', lineHeight: 1.05 }}>
+        <span style={{ fontWeight: 600, fontSize: 14 }}>{asset.symbol}</span>
+        {network && <span style={{ fontSize: 10, fontWeight: 500, color: T.faint }}>{network}</span>}
+      </span>
       <Icon d={I.chev} size={14} style={{ color: T.faint, transform: 'rotate(90deg)' }} />
     </button>
   );


### PR DESCRIPTION
## What & why

Completes the **asset-detail-hero** page and wires the two fixes requested for it.

### Requested fixes
- **Tokens now load automatically on asset-page open.** Previously the page showed *"No Tokens Found"* on first view and the user had to press **Discover Tokens**. Root cause: the background's `discovering` flag is *global* (any cached token on any chain — or a completed forced discovery — clears it), so a network opened for the first time could hold zero cached token rows yet report `discovering=false`. `Tokens.tsx` now auto-kicks **one** forced portfolio discovery per network when its cache is empty and the background isn't already discovering; `BALANCES_UPDATED` repaints the list when it commits.
- **Balances show 8-decimal precision with a "dust" tail.** Replaces `toFixed(4)`: the integer + first 4 decimals read at full size, decimals 5–8 render smaller and dimmer (`DustAmount`), so sub‑0.0001 precision is visible without crowding the headline. Trailing‑zero dust is trimmed (`0.5` → `0.5000`).

### Feature work on this branch
- Spinning KeepKey **hero** carries the asset + balance on its OLED, replacing the static icon block; branded `SpinningDevice` loaders replace `kk.gif` on the Loading / Connect (offline) / welcome screens.
- **EVM gas-asset + network labeling** so same-symbol assets are distinguishable — native rows read *"Ethereum / ETH on Base"*; swap rows show the network under the symbol (`EVM_NATIVE_GAS`, `getNetworkName()`, `networkLabelFor()`).

### Hardening from an adversarial self-review (before commit)
- **Spinner no longer hangs:** the auto-discover "Discovering…" state self-clears on the background's no-broadcast / error paths (no pubkeys yet, wallet not initialized, Pioneer 5xx), not only on dispatch failure.
- **No redundant heavy refresh:** the per-network dedup set is module-scoped (not a per-component ref), so it survives the asset Drawer's unmount/remount and won't re-fire a full `/portfolio` force-refresh every time a token-less chain is reopened.
- **Fix found during review:** ARB / OP / MATIC *governance ERC-20s* (whose tickers equal their chain's dropdown symbol) were being mislabeled as the chain's native gas asset — the symbol-match fallback now excludes token rows (`!asset.token`).

### Known minor (not addressed)
- A native-unit balance with an 11+ digit integer part could clip inside the fixed-width OLED face. Not a regression (same length as the old `toFixed(4)`), unrealistic for native units, and the authoritative USD value + wrapping subtitle still show the amount.

## Testing
- `make type-check` ✅ (15/15)
- `make lint` ✅ (0 errors)
- `make build` ✅ (Chrome bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)