### PR TITLE
fix(background): init wallet on demand so dApp RPCs survive SW cold start

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -231,7 +231,7 @@ async function checkKeepKey() {
       } else if (!wallet.isInitialized() && mayProbe) {
         // First-run case: init failed earlier (no device, no cache) — retry.
         lastDeviceProbeAt = now;
-        onStart();
+        ensureStarted();
       } else if (wallet.isInitialized() && wallet.isDeviceConnected()) {
         // Steady state: vault-up, device-connected. Periodically re-probe
         // features to verify the same physical device is still paired. A
@@ -1082,8 +1082,24 @@ const onStart = async function () {
   }
 };
 
+// Single-flight wrapper around onStart(). A dApp typically fires several RPCs
+// the instant it connects (eth_requestAccounts + eth_chainId + eth_accounts),
+// and the side panel's ON_START plus the 5s health-poll retry can overlap them.
+// wallet.init() is already single-flight, but the account-loading / migration /
+// ADDRESS-resolution tail of onStart is not — without this each caller would run
+// a full onStart (redundant account reloads, parallel device xpub batches).
+// Collapse concurrent callers into one run.
+let onStartInFlight: Promise<void> | null = null;
+function ensureStarted(): Promise<void> {
+  if (onStartInFlight) return onStartInFlight;
+  onStartInFlight = onStart().finally(() => {
+    onStartInFlight = null;
+  });
+  return onStartInFlight;
+}
+
 setTimeout(() => {
-  onStart();
+  ensureStarted();
 }, 5000);
 
 chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: any) => {
@@ -1093,6 +1109,19 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
     try {
       switch (message.type) {
         case 'WALLET_REQUEST': {
+          // MV3 evicts the service worker after ~30s idle, wiping all in-memory
+          // wallet state. A dApp's first RPC (typically eth_requestAccounts)
+          // wakes the worker, but boot init runs on a 5s timer and the retry-
+          // aware vault probe can take several seconds more — so throwing here
+          // rejected any request that landed in that window ("Wallet not
+          // initialized"). Init on demand and wait for it instead of rejecting
+          // the dApp; ensureStarted() single-flights so a burst of connect-time
+          // RPCs shares one init. Only throw if the wallet is genuinely
+          // uninitialized (no device and no cached pubkeys) after init runs.
+          if (!wallet.isInitialized()) {
+            console.warn(tag, 'WALLET_REQUEST before wallet ready — initializing on demand');
+            await ensureStarted();
+          }
           if (!wallet.isInitialized()) throw Error('Wallet not initialized');
           const { requestInfo } = message;
           const { method, params, chain } = requestInfo;
@@ -1182,7 +1211,7 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
         }
 
         case 'ON_START': {
-          onStart();
+          ensureStarted();
           setTimeout(() => {
             sendResponse({ state: KEEPKEY_STATE });
           }, 15000);


### PR DESCRIPTION
## Problem

dApp `eth_requestAccounts` is rejected with **`Wallet not initialized`**:

```
[HANDOFF] dApp ← KeepKey (ethereum/eth_requestAccounts) REJECT
  params=[]
  error= Wallet not initialized
```

The extension appears "totally broken" — connecting any dApp fails intermittently/constantly.

## Root cause

MV3 evicts the background service worker after ~30s idle, wiping **all** in-memory wallet state (`wallet.ts` `state`, `ADDRESS`, `KEEPKEY_STATE`). A dApp's first RPC wakes the worker, but:

- boot init runs on a **5s `setTimeout`**, and
- PR #85's retry-aware `probeVaultAuth` adds **several more seconds** before `wallet.init()` resolves.

The `WALLET_REQUEST` handler threw `Wallet not initialized` **immediately** for any request landing in that window — it never *triggered* init. PR #85 lengthening the init window turned this from an occasional race into a constant failure.

## Fix

`WALLET_REQUEST` now **awaits init on demand** instead of rejecting the dApp, and only throws if the wallet is *genuinely* uninitialized (no device **and** no cached pubkeys) after init completes:

```ts
if (!wallet.isInitialized()) {
  await ensureStarted();        // wait for init instead of rejecting
}
if (!wallet.isInitialized()) throw Error('Wallet not initialized');
```

`ensureStarted()` is a single-flight wrapper around the existing `onStart()`. The boot timer, `ON_START`, and the health-poll retry all route through it, so a **burst** of connect-time RPCs (`eth_requestAccounts` + `eth_chainId` + `eth_accounts`) shares **one** init rather than stacking redundant runs / parallel device xpub batches.

### Why await the full `onStart`, not just `wallet.init()`
The module-level `ADDRESS` that `eth_requestAccounts` returns is set in `onStart`'s body — a bare `init()` would return an empty address (`['']`). `onStart` catches internally and never re-throws, so `ensureStarted()` always settles (bounded by `probeVaultAuth`'s retry budget; no new unbounded await).

### No latency / no regression
- The `await` is **skipped entirely** in steady state and view-only mode (`isInitialized()` is already true) — warm read RPCs like `eth_chainId` pay zero added latency.
- Device hot-swap / re-pair paths don't route through the single-flight (they go through `handleDeviceSwitch` → `wallet.refreshPubkeys()`), so the latch can't mask a swap.
- `ON_START`'s 15s `sendResponse` timing is unchanged (the wrapper's promise is discarded exactly as `onStart()`'s return was).

## Verification
- `make type-check` — 15/15 packages pass.
- Adversarial multi-lens review (race/deadlock, regression-vs-PR#85, correctness) with independent verification: no deadlock, no TDZ/hoisting issue, no regression, fix confirmed complete. Only flagged items are pre-existing latent edges with intended behavior, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)