### PR TITLE
fix(eth): populate explorerTxLink on all EVM provider-build paths

### DIFF
--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -507,6 +507,9 @@ const handleWalletSwitchEthereumChain = async (params: any, KEEPKEY_WALLET: any,
         caip: pioneerChain.caip,
         networkId,
         name: pioneerChain.name,
+        // Carry the explorer tx-link prefix so post-switch sends deep-link
+        // the txid on TxidPage instead of showing a bare hash.
+        explorerTxLink: pioneerChain.explorerTxLink,
         providerUrl: pioneerChain.rpc,
         providers: pioneerChain.rpcs,
       },

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1033,8 +1033,13 @@ const onStart = async function () {
           await web3ProviderStorage.saveWeb3Provider({
             chainId: ethInfo.chainId,
             caip: ethInfo.caip,
+            networkId: ethInfo.networkId,
             blockExplorerUrls: ethInfo.explorer ? [ethInfo.explorer] : [],
             name: ethInfo.name,
+            // Carry the explorer tx-link prefix so TxidPage can deep-link the
+            // txid after a send. Without it the success screen shows a bare
+            // hash with no "View on Explorer" link.
+            explorerTxLink: ethInfo.explorerTxLink,
             providerUrl: ethInfo.rpc,
             // Full list (primary included) under `providers` — the key the
             // failover loops (getProvider / withRpcFailover) actually read.
@@ -1436,8 +1441,12 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
                     providerData = {
                       chainId: chainInfo.chainId,
                       caip: chainInfo.caip,
+                      networkId: chainInfo.networkId,
                       blockExplorerUrls: chainInfo.explorer ? [chainInfo.explorer] : [],
                       name: chainInfo.name,
+                      // Carry the explorer tx-link prefix so TxidPage deep-links
+                      // the txid (otherwise the success screen shows a bare hash).
+                      explorerTxLink: chainInfo.explorerTxLink,
                       providerUrl: chainInfo.rpc,
                       providers: chainInfo.rpcs,
                     };


### PR DESCRIPTION
## Problem
`TxidPage` renders a bare transaction hash with no **View on Explorer** link whenever the stored web3 provider lacks `explorerTxLink`. Three provider-build paths dropped the field even though `getChainInfo()` (Pioneer registry) supplies it:

1. **`index.ts` `onStart` default ETH provider** — the common cold-start mainnet send path (no chain switch).
2. **`index.ts` `SET_ASSET_CONTEXT` Pioneer fallback** — selecting an asset whose chain isn't in custom storage.
3. **`ethereumHandler.ts` `wallet_switchEthereumChain` Pioneer-switch** — `switchToProvider` input.

The two `transaction_complete` senders read `explorerTxLink` straight from the stored provider, so the fix is at the source: carry `explorerTxLink` (+ `networkId`) from `ChainInfo` at each build site. This also restores the address-explorer links in the asset/switch UIs that read the same stored provider.

## Why not just merge #53
This **re-implements #53** in current form. #53's `EIP155_CHAINS` fallback is obsolete — that static table was replaced by the Pioneer `registry.ts`. #53 was also conflicting/red. Closing it in favor of this.

## Verification
- ✅ `make type-check` — 15/15
- ✅ `pnpm test` — 91/91
- Fields verified against `ChainInfo` (`registry.ts:99,105`) and `Web3Provider` (optional `networkId`/`explorerTxLink`).

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)