### PR TITLE
fix(connection): clear "Vault not running" error to dApps instead of silent failure

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -43,7 +43,7 @@ import {
 import { getChainInfo } from './chains/registry';
 import { withRpcFailoverByNetworkId } from './chains/rpcFailover';
 import { EVM_TESTNETS, SOLANA_DEVNET, ALL_TESTNET_NETWORK_IDS } from './testnetPresets';
-import { formatUserError } from './utils';
+import { formatUserError, createVaultRequiredError } from './utils';
 import { partitionSpamTokens, getTokenVisibilityMap, setTokenVisibility } from './spamFilter';
 
 const TAG = ' | background/index.js | ';
@@ -1127,7 +1127,14 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             console.warn(tag, 'WALLET_REQUEST before wallet ready — initializing on demand');
             await ensureStarted();
           }
-          if (!wallet.isInitialized()) throw Error('Wallet not initialized');
+          if (!wallet.isInitialized()) {
+            // Distinguish "vault is closed" (state 4) from a transient init race
+            // so the dApp gets the actionable "launch the Vault" message instead
+            // of a bare "Wallet not initialized". The side panel already shows
+            // the Connect/Vault-Required card off the same state.
+            if (KEEPKEY_STATE === 4) throw createVaultRequiredError();
+            throw Error('Wallet not initialized');
+          }
           const { requestInfo } = message;
           const { method, params, chain } = requestInfo;
 

--- a/chrome-extension/src/background/utils.test.ts
+++ b/chrome-extension/src/background/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { createProviderRpcError, createTimeoutError, formatUserError } from './utils';
+import {
+  createProviderRpcError,
+  createTimeoutError,
+  createVaultRequiredError,
+  formatUserError,
+  isVaultUnreachableError,
+  VAULT_REQUIRED_MESSAGE,
+} from './utils';
 
 describe('createProviderRpcError', () => {
   it('sets the code and message', () => {
@@ -29,7 +36,35 @@ describe('createTimeoutError', () => {
   });
 });
 
+describe('createVaultRequiredError', () => {
+  it('uses EIP-1193 disconnected code 4900 and the canonical vault message', () => {
+    const e = createVaultRequiredError();
+    expect(e.code).toBe(4900);
+    expect(e.message).toBe(VAULT_REQUIRED_MESSAGE);
+    expect(e.message).toContain('keepkey.com/launch');
+  });
+});
+
+describe('isVaultUnreachableError', () => {
+  it.each([
+    'TypeError: Failed to fetch',
+    'Load failed',
+    'NetworkError when attempting to fetch resource',
+    'connect ECONNREFUSED 127.0.0.1:1646',
+  ])('detects vault-down network error: %s', msg => {
+    expect(isVaultUnreachableError(msg)).toBe(true);
+  });
+
+  it('does not flag unrelated errors', () => {
+    expect(isVaultUnreachableError('User rejected the request')).toBe(false);
+  });
+});
+
 describe('formatUserError', () => {
+  it('translates a vault-unreachable network error into the launch instruction', () => {
+    expect(formatUserError(new Error('TypeError: Failed to fetch'))).toBe(VAULT_REQUIRED_MESSAGE);
+  });
+
   it('translates the vault "No device connected" error into a friendly message', () => {
     const e = new Error('SdkError: No device connected');
     expect(formatUserError(e)).toBe('Please connect your KeepKey device and try again.');

--- a/chrome-extension/src/background/utils.ts
+++ b/chrome-extension/src/background/utils.ts
@@ -29,11 +29,37 @@ export const createTimeoutError = (message: string): ProviderRpcError =>
   createProviderRpcError(-32603, message, undefined, 'timeout');
 
 /**
- * Translate vault SdkError ("No device connected") into a user-facing message.
+ * Shown whenever the KeepKey Vault desktop app (REST server on localhost:1646)
+ * is unreachable. Mirrors the side panel's Connect "KeepKey Vault Required"
+ * card so the dApp sees the same instruction instead of a raw "Failed to fetch".
+ */
+export const VAULT_REQUIRED_MESSAGE =
+  'KeepKey Vault is not running. Open the KeepKey Vault desktop app, then try again. Get it at https://keepkey.com/launch';
+
+/** EIP-1193 4900 = "provider disconnected from all chains" — fits a down vault. */
+export const createVaultRequiredError = (): ProviderRpcError => createProviderRpcError(4900, VAULT_REQUIRED_MESSAGE);
+
+/**
+ * True when an error came from the vault REST server being down. The signing
+ * path fetches localhost:1646; when the vault is closed that rejects with a
+ * network error whose message varies by browser/runtime ("Failed to fetch",
+ * "Load failed", "NetworkError", "ECONNREFUSED").
+ */
+export function isVaultUnreachableError(msg: string): boolean {
+  return /failed to fetch|load failed|networkerror|econnrefused|fetch failed|err_connection_refused/i.test(msg);
+}
+
+/**
+ * Translate low-level errors into user-facing messages:
+ *  - vault unreachable (localhost:1646 down) → "Vault not running" instruction
+ *  - vault SdkError ("No device connected")  → connect-device instruction
  * All other errors pass through unchanged.
  */
 export function formatUserError(err: unknown): string {
   const msg = (err as Error)?.message ?? String(err);
+  if (isVaultUnreachableError(msg)) {
+    return VAULT_REQUIRED_MESSAGE;
+  }
   if (msg.includes('No device connected')) {
     return 'Please connect your KeepKey device and try again.';
   }


### PR DESCRIPTION
## Problem
When the KeepKey Vault desktop app (REST server on `localhost:1646`) is closed, dApp requests through `window.ethereum` (and other chains) failed with a cryptic `Failed to fetch` or a bare `Wallet not initialized`. From the user's seat the dApp just silently errors — nothing tells them the Vault needs to be running.

The side panel **already** has the gate/UI: at `KEEPKEY_STATE === 4` it renders `Connect.tsx`'s "KeepKey Vault Required" card with a Launch button → `https://keepkey.com/launch`. The dApp-facing path just didn't deliver the same message.

## Fix
- **`utils.ts`** — add `VAULT_REQUIRED_MESSAGE` + `createVaultRequiredError()` (EIP-1193 code `4900` "provider disconnected"). Message mirrors the side-panel card and points at `keepkey.com/launch`.
- **`utils.ts`** — `formatUserError()` now translates vault-unreachable network errors (`Failed to fetch` / `Load failed` / `NetworkError` / `ECONNREFUSED`) into that message. This is the **universal backstop**: it covers every chain/method at signing time without enumerating them, since all signing fetches `localhost:1646`.
- **`index.ts`** — the `WALLET_REQUEST` init gate fails fast with the launch instruction when the vault is down (state 4), instead of throwing `Wallet not initialized`.

Read-only RPCs served from cache/external providers (e.g. `eth_call`, `eth_chainId`) are unaffected — only requests that actually need the vault surface the error.

## Test
Extends `utils.test.ts` (vitest): `createVaultRequiredError` code/message, `isVaultUnreachableError` detection across browser/runtime variants, and `formatUserError` translation. `vitest run` → 14 passing; `tsc --noEmit` clean.

## Not in scope
The "clear message in the vault app" half (vault-side) lives in a different repo — this PR is the extension side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)